### PR TITLE
fix compilation of 'stats' module by providing separate defaultPackages for 'compile' and 'test'  phases.

### DIFF
--- a/packages/stats/pom.xml
+++ b/packages/stats/pom.xml
@@ -58,13 +58,6 @@
         <groupId>org.renjin</groupId>
         <artifactId>renjin-maven-plugin</artifactId>
         <version>${project.version}</version>
-        <configuration>
-          <defaultPackages>
-              <!-- grDevices is required for some of the tests in the stats package -->
-              <package>grDevices</package>
-              <package>stats</package>
-          </defaultPackages>
-        </configuration>
         <executions>
           <execution>
             <id>build</id>
@@ -73,11 +66,6 @@
               <goal>gnur-sources-compile</goal>
             </goals>
             <phase>compile</phase>
-            <configuration>
-               <defaultPackages>
-                 <package>grDevices</package>
-               </defaultPackages>
-            </configuration>
           </execution>
           <execution>
             <id>test</id>
@@ -85,6 +73,12 @@
               <goal>test</goal>
             </goals>
             <phase>test</phase>
+            <configuration>
+               <defaultPackages>
+                 <package>grDevices</package>
+                 <package>stats</package>
+               </defaultPackages>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Good day, colleagues.

Currently compilation of renjin 'from strath'  fail, because renjin-maven-plugin try to load 'stats' as default package during compilation of module 'stats'  (when environment is not yet compiled).  

Proposed path fixes this, providing separate defaultPackages for 'compile' and 'test'  phases.
