### PR TITLE
Issue #201: Wrap EvalException in ScriptException

### DIFF
--- a/script-engine/src/main/java/org/renjin/script/RenjinScriptEngine.java
+++ b/script-engine/src/main/java/org/renjin/script/RenjinScriptEngine.java
@@ -145,14 +145,15 @@ public class RenjinScriptEngine implements ScriptEngine, Invocable {
     return eval(context, source);
   }
   
-  private Object eval(Context context, SEXP source) {
+  private Object eval(Context context, SEXP source) throws ScriptException {
     try {
       return context.evaluate( source, context.getEnvironment());
     } catch(BreakException e) {
-      throw new EvalException("no loop for break");
+      throw new ScriptException("no loop for break");
     } catch(NextException e) {
-      throw new EvalException("no loop for next");
-
+      throw new ScriptException("no loop for next");
+    } catch (EvalException e) {
+      throw new ScriptException(e);
     }
   }
 


### PR DESCRIPTION
This commit would wrap any EvalExceptions thrown during the course of the script execution in a standard ScriptException class that is common to all ScriptEngine implementations. 