### PR TITLE
Fix #71: Guard parseDouble against additional characters

### DIFF
--- a/core/src/main/java/org/renjin/parser/NumericLiterals.java
+++ b/core/src/main/java/org/renjin/parser/NumericLiterals.java
@@ -143,6 +143,9 @@ public class NumericLiterals {
     while ( p < endIndex && Character.isWhitespace(s.charAt(p))) {
       p++;
     }
+    while ( endIndex >= p && Character.isWhitespace(s.charAt(endIndex-1))) {
+      endIndex--;
+    }
 
     if (NA && (p+2 < endIndex) && s.charAt(p) == 'N' && s.charAt(p+1) == 'A') {
       ans = DoubleVector.NA;
@@ -234,6 +237,14 @@ public class NumericLiterals {
           ans *= fac;
         }
       }
+
+      // Safeguard against malformed input
+      if(p < endIndex){
+        ans = DoubleVector.NA;
+        p = 0; /* back out */
+        return (sign * ans);
+      }
+
       return sign * ans;
     }
 
@@ -266,6 +277,13 @@ public class NumericLiterals {
         n = n * 10 + (s.charAt(p) - '0');
       }
       expn += expsign * n;
+    }
+
+    // Safeguard against malformed input
+    if(p < endIndex){
+      ans = DoubleVector.NA;
+      p = 0; /* back out */
+      return (sign * ans);
     }
   
       /* avoid unnecessary underflow for large negative exponents */

--- a/core/src/main/java/org/renjin/parser/NumericLiterals.java
+++ b/core/src/main/java/org/renjin/parser/NumericLiterals.java
@@ -143,7 +143,7 @@ public class NumericLiterals {
     while ( p < endIndex && Character.isWhitespace(s.charAt(p))) {
       p++;
     }
-    while ( endIndex >= p && Character.isWhitespace(s.charAt(endIndex-1))) {
+    while ( endIndex > p && Character.isWhitespace(s.charAt(endIndex-1))) {
       endIndex--;
     }
 

--- a/core/src/test/java/org/renjin/sexp/NumericLiteralsTest.java
+++ b/core/src/test/java/org/renjin/sexp/NumericLiteralsTest.java
@@ -1,3 +1,21 @@
+/**
+ * Renjin : JVM-based interpreter for the R language for the statistical analysis
+ * Copyright © 2010-2016 BeDataDriven Groep B.V. and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, a copy is available at
+ * https://www.gnu.org/licenses/gpl-2.0.txt
+ */
 package org.renjin.sexp;
 
 import org.junit.Test;

--- a/core/src/test/java/org/renjin/sexp/NumericLiteralsTest.java
+++ b/core/src/test/java/org/renjin/sexp/NumericLiteralsTest.java
@@ -1,0 +1,29 @@
+package org.renjin.sexp;
+
+import org.junit.Test;
+import org.renjin.parser.NumericLiterals;
+
+import static org.junit.Assert.assertTrue;
+
+public class NumericLiteralsTest {
+
+  @Test
+  public void testParseDouble() {
+
+    assertTrue("Can parse simple literal", NumericLiterals.parseDouble("2") == 2);
+    assertTrue("Ignores whitespace at beginning", NumericLiterals.parseDouble(" 2") == 2);
+    assertTrue("Ignores whitespace at end", NumericLiterals.parseDouble("2 ") == 2);
+    assertTrue("Can parse simple literal with sign", NumericLiterals.parseDouble("-2") == -2);
+    assertTrue("Can parse NA", Double.isNaN(NumericLiterals.parseDouble("NA")));
+    assertTrue("Can parse decimal", NumericLiterals.parseDouble("2.4") == 2.4);
+    assertTrue("Can parse exponent", NumericLiterals.parseDouble("2.4e5") == 2.4e5);
+    assertTrue("Can parse hexadecimal", NumericLiterals.parseDouble("0x5") == 0x5);
+    assertTrue("Can parse infinity", NumericLiterals.parseDouble("Inf") == Double.POSITIVE_INFINITY);
+
+    // Test cases that cannot be parsed and thus return NaN
+    assertTrue("Illegal character return NaN", Double.isNaN(NumericLiterals.parseDouble("a")));
+    assertTrue("Whitespace in literal returns NaN", Double.isNaN(NumericLiterals.parseDouble("4 2")));
+    assertTrue("Whitespace in hexadecimals returns NaN", Double.isNaN(NumericLiterals.parseDouble("0xep2 2")));
+  }
+
+}

--- a/core/src/test/java/org/renjin/sexp/NumericLiteralsTest.java
+++ b/core/src/test/java/org/renjin/sexp/NumericLiteralsTest.java
@@ -42,6 +42,8 @@ public class NumericLiteralsTest {
     assertTrue("Illegal character return NaN", Double.isNaN(NumericLiterals.parseDouble("a")));
     assertTrue("Whitespace in literal returns NaN", Double.isNaN(NumericLiterals.parseDouble("4 2")));
     assertTrue("Whitespace in hexadecimals returns NaN", Double.isNaN(NumericLiterals.parseDouble("0xep2 2")));
+    assertTrue("Empty string return NaN", Double.isNaN(NumericLiterals.parseDouble("")));
+    assertTrue("Empty string with whitespace return NaN", Double.isNaN(NumericLiterals.parseDouble(" ")));
   }
 
 }


### PR DESCRIPTION
This should fix issue #71 where as.numeric did not handle for example "1/2" correctly.
@akbertram mentioned that he wasn't sure, if fixing this issue might cause trouble in the lexer, because it also uses the method parseDouble, but as far as I can see in that case it is called with the correct start and end index, so that there are no problems.