### PR TITLE
Implements calling handlers and restarts

### DIFF
--- a/core/src/main/java/org/renjin/eval/ClosureDispatcher.java
+++ b/core/src/main/java/org/renjin/eval/ClosureDispatcher.java
@@ -81,8 +81,16 @@ public class ClosureDispatcher {
 
 
     } catch(ConditionException e) {
-      if(e.getHandlerContext() == functionContext) {
+      if (e.getHandlerContext() == functionContext) {
         return new ListVector(e.getCondition(), Null.INSTANCE, e.getHandler());
+      } else {
+        throw e;
+      }
+
+    } catch (RestartException e) {
+      if(e.getExitEnvironment() == functionContext.getEnvironment()) {
+        // This return value is consumed by the R code in conditions.R
+        return e.getArguments();
       } else {
         throw e;
       }

--- a/core/src/main/java/org/renjin/eval/ClosureDispatcher.java
+++ b/core/src/main/java/org/renjin/eval/ClosureDispatcher.java
@@ -108,9 +108,9 @@ public class ClosureDispatcher {
   
   private static SEXP findHandler(Context context, Iterable<String> conditionClasses) {
     for(String conditionClass : conditionClasses) {
-      SEXP handler = context.getConditionHandler(conditionClass);
+      ConditionHandler handler = context.getConditionHandler(conditionClass);
       if(handler != null) {
-        return handler;
+        return handler.getFunction();
       }
     }
     return null;

--- a/core/src/main/java/org/renjin/eval/ConditionHandler.java
+++ b/core/src/main/java/org/renjin/eval/ConditionHandler.java
@@ -1,0 +1,54 @@
+/**
+ * Renjin : JVM-based interpreter for the R language for the statistical analysis
+ * Copyright © 2010-2016 BeDataDriven Groep B.V. and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, a copy is available at
+ * https://www.gnu.org/licenses/gpl-2.0.txt
+ */
+package org.renjin.eval;
+
+import org.renjin.sexp.Function;
+import org.renjin.sexp.SEXP;
+
+/**
+ * A handler registration for a condition.
+ */
+public class ConditionHandler {
+
+  /**
+   * The function to invoke if a signal is handled
+   */
+  private SEXP handler;
+
+
+  /**
+   * True if this is a calling handler. Calling handlers are executed in the context
+   * in which the condition is signaled. If {@code false}, the control is first returned
+   * to the {@link Context} in which the handler was registered.
+   */
+  private boolean calling;
+
+  public ConditionHandler(SEXP handler, boolean calling) {
+    this.handler = handler;
+    this.calling = calling;
+  }
+
+  public SEXP getFunction() {
+    return handler;
+  }
+
+  public boolean isCalling() {
+    return calling;
+  }
+}

--- a/core/src/main/java/org/renjin/eval/Context.java
+++ b/core/src/main/java/org/renjin/eval/Context.java
@@ -174,10 +174,20 @@ public class Context {
     return stack;
   }
 
-  public SEXP evaluateCallingHandler(Context definitionContext, SEXP expression) {
+  /**
+   * Evaluates the given calling handler function call in this context, but temporarily sets
+   * the conditionStack pointer to the parent of the context in which the handler was defined.
+   *
+   * <p>This ensures that a signal can be rethrown within the condition handler and not be caught
+   * infinitely.</p>
+   *
+   * @param definitionContext the context in which the condition handler was defined.
+   * @param handlerCall the function call to evaluate.
+   */
+  public SEXP evaluateCallingHandler(Context definitionContext, SEXP handlerCall) {
     this.session.conditionStack = definitionContext.getParent();
     try {
-      return evaluate(expression);
+      return evaluate(handlerCall);
     } finally {
       this.session.conditionStack = null;
     }
@@ -310,8 +320,9 @@ public class Context {
   }
 
   /**
-   * Tries to find a restart with the given name in this context or
+   * Tries to find a restart in this context or
    * one of it's parents.
+   *
    * @param index the zero-based index of the restart to find. Index "0" is the last added restart
    *            in this context or its nearest parent.
    */

--- a/core/src/main/java/org/renjin/eval/Context.java
+++ b/core/src/main/java/org/renjin/eval/Context.java
@@ -108,7 +108,7 @@ public class Context {
    * Handlers are R functions that are called immediately when
    * conditions are signaled.
    */
-  private Map<String, SEXP> conditionHandlers = Maps.newHashMap();
+  private Map<String, ConditionHandler> conditionHandlers = Maps.newHashMap();
 
   private Map<Class, Object> stateMap = null;
 
@@ -475,14 +475,17 @@ public class Context {
    * @see org.renjin.primitives.Conditions
    *
    * @param conditionClass  the (S3) condition class to be handled by this handler.
-   * @param function an expression that evaluates to a function that accepts a signaled
+   * @param function a function that accepts a signaled
    * condition as an argument.
+   * @param calling true if this is a "calling" handler and should be invoked in the {@code Context}
+   *                 in which the condition is signaled, {@code false} if control should first
+   *                 be returned to the {@code Context} in which it was registered.
    */
-  public void setConditionHandler(String conditionClass, SEXP function) {
-    conditionHandlers.put(conditionClass, function);
+  public void setConditionHandler(String conditionClass, SEXP function, boolean calling) {
+    conditionHandlers.put(conditionClass, new ConditionHandler(function, calling));
   }
 
-  public SEXP getConditionHandler(String conditionClass) {
+  public ConditionHandler getConditionHandler(String conditionClass) {
     return conditionHandlers.get(conditionClass);
   }
 

--- a/core/src/main/java/org/renjin/eval/RestartException.java
+++ b/core/src/main/java/org/renjin/eval/RestartException.java
@@ -1,0 +1,52 @@
+/**
+ * Renjin : JVM-based interpreter for the R language for the statistical analysis
+ * Copyright © 2010-2016 BeDataDriven Groep B.V. and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, a copy is available at
+ * https://www.gnu.org/licenses/gpl-2.0.txt
+ */
+package org.renjin.eval;
+
+import org.renjin.primitives.special.ControlFlowException;
+import org.renjin.sexp.Environment;
+import org.renjin.sexp.Function;
+import org.renjin.sexp.ListVector;
+
+/**
+ * Raised to return control flow to the context in which a restart was defined.
+ *
+ */
+public class RestartException extends ControlFlowException {
+  private Environment exitEnvironment;
+  private Function handler;
+  private ListVector arguments;
+
+  public RestartException(Environment exitEnvironment, Function handler, ListVector arguments) {
+    this.exitEnvironment = exitEnvironment;
+    this.handler = handler;
+    this.arguments = arguments;
+  }
+
+  public Environment getExitEnvironment() {
+    return exitEnvironment;
+  }
+
+  public Function getHandler() {
+    return handler;
+  }
+
+  public ListVector getArguments() {
+    return arguments;
+  }
+}

--- a/core/src/main/java/org/renjin/eval/Session.java
+++ b/core/src/main/java/org/renjin/eval/Session.java
@@ -115,6 +115,14 @@ public class Session {
    */
   boolean invisible;
 
+
+  /**
+   * When this is set, we are evaluating a calling handler and should only match handlers at this
+   * level or higher.
+   */
+  Context conditionStack = null;
+
+
   Session(FileSystemManager fileSystemManager,
           ClassLoader classLoader,
           PackageLoader packageLoader,
@@ -309,6 +317,8 @@ public class Session {
   public ClassLoader getClassLoader() {
     return classLoader;
   }
+
+
 
   public void registerFinalizer(SEXP sexp, FinalizationHandler handler, boolean onExit) {
     if(finalizers == null) {

--- a/core/src/main/java/org/renjin/primitives/Conditions.java
+++ b/core/src/main/java/org/renjin/primitives/Conditions.java
@@ -19,6 +19,7 @@
 package org.renjin.primitives;
 
 import org.renjin.eval.ConditionException;
+import org.renjin.eval.ConditionHandler;
 import org.renjin.eval.Context;
 import org.renjin.eval.EvalException;
 import org.renjin.invoke.annotations.Current;
@@ -134,7 +135,7 @@ public class Conditions {
                                           ListVector handlers,
                                           Environment parentEnv,
                                           SEXP target,
-                                          LogicalVector calling) {
+                                          boolean calling) {
 
     if(classes.length() != handlers.length()) {
       throw new EvalException("bad handler data");
@@ -144,26 +145,59 @@ public class Conditions {
 
     for (int i = n - 1; i >= 0; i--) {
       context.setConditionHandler(classes.getElementAsString(i),
-          Promise.repromise(parentEnv, handlers.getElementAsSEXP(i)));
+          Promise.repromise(parentEnv, handlers.getElementAsSEXP(i)), calling);
     }
   }
 
   @Internal(".addRestart")
-  public static void addRestart(SEXP restart) {
-    // TODO : implement
+  public static void addRestart(@Current Context context, SEXP restart) {
+    throw new UnsupportedOperationException("TODO");
+  }
+
+  @Internal(".getRestart")
+  public static SEXP getRestart(@Current Context context, int index) {
+    throw new UnsupportedOperationException("TODO");
   }
 
 
   @Internal(".signalCondition")
   public static void signalCondition(@Current Context context, SEXP condition, String message, SEXP call) {
 
+    //  If a condition is signaled while evaluating ‘expr’ then
+    //  established handlers are checked, starting with the most recently
+    //  established ones, for one matching the class of the condition.
+    //  When several handlers are supplied in a single ‘tryCatch’ then the
+    //  first one is considered more recent than the second.  If a handler
+    //  is found then control is transferred to the ‘tryCatch’ call that
+    //  established the handler, the handler found and all more recent
+    //  handlers are disestablished, the handler is called with the
+    //  condition as its argument, and the result returned by the handler
+    //  is returned as the value of the ‘tryCatch’ call.
+    //
+    //      Calling handlers are established by ‘withCallingHandlers’.  If a
+    //  condition is signaled and the applicable handler is a calling
+    //  handler, then the handler is called by ‘signalCondition’ in the
+    //  context where the condition was signaled but with the available
+    //  handlers restricted to those below the handler called in the
+    //  handler stack.  If the handler returns, then the next handler is
+    //  tried; once the last handler has been tried, ‘signalCondition’
+    //  returns ‘NULL’.
+
     StringVector conditionClasses = condition.getS3Class();
 
     while(!context.isTopLevel()) {
       for(String conditionClass : conditionClasses) {
-        SEXP handler = context.getConditionHandler(conditionClass);
+        ConditionHandler handler = context.getConditionHandler(conditionClass);
         if(handler != null) {
-          throw new ConditionException(condition, context, handler);
+          if(handler.isCalling()) {
+            // For "calling" handlers, we invoke in THIS context
+            FunctionCall handlerCall = FunctionCall.newCall(handler.getFunction(), condition);
+            context.evaluate(handlerCall);
+
+          } else {
+            // otherwise return control to the context in which the handler was defined
+            throw new ConditionException(condition, context, handler.getFunction());
+          }
         }
       }
 

--- a/core/src/main/java/org/renjin/primitives/Primitives.java
+++ b/core/src/main/java/org/renjin/primitives/Primitives.java
@@ -181,8 +181,8 @@ public class Primitives {
     f(".dfltStop", Conditions.class, 11);
     f(".dfltWarn", /*dfltWarn*/ null, 11);
     f(".addRestart", Conditions.class, 11);
-    f(".getRestart", /*getRestart*/ null, 11);
-    f(".invokeRestart", /*invokeRestart*/ null, 11);
+    f(".getRestart", Conditions.class, 11);
+    f(".invokeRestart", Conditions.class, 11);
     f(".addTryHandlers", /*addTryHandlers*/ null, 111);
 
     f("geterrmessage", Conditions.class, 11);

--- a/core/src/main/java/org/renjin/primitives/special/AssignLeftFunction.java
+++ b/core/src/main/java/org/renjin/primitives/special/AssignLeftFunction.java
@@ -59,8 +59,8 @@ public class AssignLeftFunction extends SpecialFunction {
 
     while(lhs instanceof FunctionCall) {
       FunctionCall call = (FunctionCall) lhs;
-      Symbol getter = (Symbol) call.getFunction();
-      Symbol setter = Symbol.get(getter.getPrintName() + "<-");
+      SEXP getter = call.getFunction();
+      SEXP setter = setterFromGetter(getter);
 
       PairList setterArgs = PairList.Node.newBuilder()
           .addAll(call.getArguments())
@@ -92,6 +92,25 @@ public class AssignLeftFunction extends SpecialFunction {
     context.setInvisibleFlag();
     
     return evaluatedValue;
+  }
+
+  private SEXP setterFromGetter(SEXP getter) {
+    if(getter instanceof Symbol) {
+      return Symbol.get(((Symbol) getter).getPrintName() + "<-");
+    }
+
+    if(getter instanceof FunctionCall) {
+      FunctionCall call = (FunctionCall) getter;
+      if(call.getArguments().length() == 2 &&
+          (call.getFunction() == Symbol.get("::") ||
+           call.getFunction() == Symbol.get(":::"))) {
+        SEXP namespace = call.getArgument(0);
+        SEXP namespacedGetter = call.getArgument(1);
+        SEXP setter = setterFromGetter(namespacedGetter);
+        return FunctionCall.newCall(call.getFunction(), namespace, setter);
+      }
+    }
+    throw new EvalException("invalid function in complex assignment");
   }
 
   protected void assignResult(Context context, Environment rho, Symbol target, SEXP rhs) {

--- a/core/src/main/java/org/renjin/sexp/ListVector.java
+++ b/core/src/main/java/org/renjin/sexp/ListVector.java
@@ -160,9 +160,17 @@ public class ListVector extends AbstractVector implements Iterable<SEXP>, HasNam
   public double getElementAsDouble(String name) {
     return getElementAsDouble(getIndexByName(name));
   }
+
+  public String getElementAsString(String name) {
+    return getElementAsString(getIndexByName(name));
+  }
   
   public ListVector getElementAsList(String name) {
     return (ListVector)getElementAsSEXP(getIndexByName(name));
+  }
+
+  public SEXP getElementAsSEXP(String name) {
+    return getElementAsSEXP(getIndexByName(name));
   }
 
   public Vector getElementAsVector(String name) {

--- a/tests/src/test/R/test.assign.R
+++ b/tests/src/test/R/test.assign.R
@@ -1,0 +1,40 @@
+#
+# Renjin : JVM-based interpreter for the R language for the statistical analysis
+# Copyright © 2010-2016 BeDataDriven Groep B.V. and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, a copy is available at
+# https://www.gnu.org/licenses/gpl-2.0.txt
+#
+
+
+library(hamcrest)
+
+test.complex.assign.ns <- function() {
+
+    x <- 41
+    base::length(x) <- 5
+
+    assertThat(x, identicalTo(c(41, NA, NA, NA, NA)))
+
+}
+
+
+test.complex.assign.ns2 <- function() {
+
+    x <- 41
+    base:::length(x) <- 5
+
+    assertThat(x, identicalTo(c(41, NA, NA, NA, NA)))
+
+}

--- a/tests/src/test/R/test.withCallingHandlers.R
+++ b/tests/src/test/R/test.withCallingHandlers.R
@@ -1,0 +1,48 @@
+#
+# Renjin : JVM-based interpreter for the R language for the statistical analysis
+# Copyright © 2010-2016 BeDataDriven Groep B.V. and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, a copy is available at
+# https://www.gnu.org/licenses/gpl-2.0.txt
+#
+
+library(hamcrest)
+
+signalerCompleted <- FALSE
+handlerCalled1 <- FALSE
+handlerCalled2 <- FALSE
+
+
+do_signal <- function() {
+
+  condition <- structure(
+    list(message = "foo"),
+    class = c("condition_a", "condition_b", "condition"))
+
+  signalCondition(condition)
+
+  # execution should continue
+  signalerCompleted <<- TRUE
+}
+
+withCallingHandlers(
+  do_signal(),
+  condition_a = function(e) { handlerCalled1 <<- TRUE },
+  condition_b = function(e) { handlerCalled2 <<- TRUE }
+)
+
+
+assertTrue(signalerCompleted)
+assertTrue(handlerCalled1)
+assertTrue(handlerCalled2)

--- a/tests/src/test/R/test.withRestarts.R
+++ b/tests/src/test/R/test.withRestarts.R
@@ -1,0 +1,53 @@
+#
+# Renjin : JVM-based interpreter for the R language for the statistical analysis
+# Copyright © 2010-2016 BeDataDriven Groep B.V. and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, a copy is available at
+# https://www.gnu.org/licenses/gpl-2.0.txt
+#
+
+library(hamcrest)
+
+signalerCompleted <- FALSE
+handlerCalled1 <- FALSE
+handlerCalled2 <- FALSE
+restartInvoked <- FALSE
+
+do_signal <- function() {
+  
+  condition <- structure(
+    list(message = "foo"),
+    class = c("condition_a", "condition_b", "condition"))
+  
+  x <- withRestarts(signalCondition(condition),
+     restart1 = function() { restartInvoked <<- TRUE; 41 },
+     restart2 = function() 42)
+  
+  # execution should continue
+  signalerCompleted <<- TRUE
+  
+  assertThat(x, identicalTo(41))
+}
+
+withCallingHandlers(
+  do_signal(),
+  condition_a = function(e) { handlerCalled1 <<- TRUE; invokeRestart("restart1") },
+  condition_b = function(e) { handlerCalled2 <<- TRUE }
+)
+
+
+assertTrue(signalerCompleted)
+assertTrue(restartInvoked)
+assertTrue(handlerCalled1)
+assertFalse(handlerCalled2)

--- a/tests/src/test/R/test.withRestarts.R
+++ b/tests/src/test/R/test.withRestarts.R
@@ -23,6 +23,7 @@ signalerCompleted <- FALSE
 handlerCalled1 <- FALSE
 handlerCalled2 <- FALSE
 restartInvoked <- FALSE
+controlFlowResumed <- FALSE
 
 do_signal <- function() {
   
@@ -30,19 +31,24 @@ do_signal <- function() {
     list(message = "foo"),
     class = c("condition_a", "condition_b", "condition"))
   
-  x <- withRestarts(signalCondition(condition),
-     restart1 = function() { restartInvoked <<- TRUE; 41 },
-     restart2 = function() 42)
-  
+  x <- withRestarts({
+    signalCondition(condition);
+    cat("Control flow resumed.\n");
+    controlFlowResumed <<- TRUE
+  },
+  restart1 = function() { 41 },
+  restart2 = function() { restartInvoked <<- TRUE; 42 }
+  )
+
   # execution should continue
   signalerCompleted <<- TRUE
-  
-  assertThat(x, identicalTo(41))
+
+  assertThat(x, identicalTo(42))
 }
 
 withCallingHandlers(
   do_signal(),
-  condition_a = function(e) { handlerCalled1 <<- TRUE; invokeRestart("restart1") },
+  condition_a = function(e) { handlerCalled1 <<- TRUE; invokeRestart("restart2"); stop("Should not reach here.") },
   condition_b = function(e) { handlerCalled2 <<- TRUE }
 )
 
@@ -51,3 +57,4 @@ assertTrue(signalerCompleted)
 assertTrue(restartInvoked)
 assertTrue(handlerCalled1)
 assertFalse(handlerCalled2)
+assertFalse(controlFlowResumed)

--- a/tools/maven-plugin/src/main/java/org/renjin/maven/test/TestExecutor.java
+++ b/tools/maven-plugin/src/main/java/org/renjin/maven/test/TestExecutor.java
@@ -31,10 +31,7 @@ import org.renjin.repackaged.guava.base.Joiner;
 import org.renjin.repackaged.guava.base.Strings;
 import org.renjin.repackaged.guava.io.Files;
 import org.renjin.repl.JlineRepl;
-import org.renjin.sexp.Closure;
-import org.renjin.sexp.FunctionCall;
-import org.renjin.sexp.SEXP;
-import org.renjin.sexp.Symbol;
+import org.renjin.sexp.*;
 
 import java.io.*;
 import java.util.Arrays;
@@ -300,6 +297,15 @@ public class TestExecutor {
       System.err.println("Loading default package " + pkg);
       loadLibrary(session, pkg, testOutput);
     }
+
+    // Setup options for testthat so that test results are written in junit format
+    // to the expected location
+    PairList.Builder options = new PairList.Builder();
+    options.add("testthat.default_check_reporter", StringVector.valueOf("junit"));
+    options.add("testthat.junit_output_file", StringVector.valueOf(
+        new File(testReportDirectory, "TEST-testthat-junit.xml").getAbsolutePath()));
+
+    session.getTopLevelContext().evaluate(new FunctionCall(Symbol.get("options"), options.build()));
 
     return session;
   }


### PR DESCRIPTION
The `testthat` package uses the calling handler and restart mechanism extensively to capture expectation results. This PR should bring full support for these language features to Renjin.