### PR TITLE
fix argument matching issues

### DIFF
--- a/core/src/main/java/org/renjin/primitives/S3.java
+++ b/core/src/main/java/org/renjin/primitives/S3.java
@@ -453,22 +453,6 @@ public class S3 {
         method = validMethods.get(0).get(0);
       }
     }
-//    if(validMethods.get(0).size() == 0) {
-//      // select closest group method if no generic methods are found
-//      method = validMethods.get(1).get(0);
-//    } else if(validMethods.get(1).size() == 0){
-//      // select closest generic method if no group methods are found
-//      method = validMethods.get(0).get(0);
-//    } else {
-//      // select closest group method if distance is less than the distance of closest generic method
-//      int genericDistance = validMethods.get(0).get(0).getDistance();
-//      int groupDistance = validMethods.get(1).get(0).getDistance();
-//      if(groupDistance < genericDistance) {
-//        method = validMethods.get(1).get(0);
-//      } else {
-//        method = validMethods.get(0).get(0);
-//      }
-//    }
     
 //     if selected method is from Group or if its from standard generic but distance is > 0
 //     returned function environment is populated with the following metadata objects:

--- a/core/src/main/java/org/renjin/primitives/S3.java
+++ b/core/src/main/java/org/renjin/primitives/S3.java
@@ -780,20 +780,20 @@ public class S3 {
   private static ArgumentSignature[] computeArgumentSignatures(Context context, Iterable<PairList.Node> nodes, Map<Symbol, SEXP> matchedMap, int currentDepth) {
   
     ArgumentSignature[] argSignatures = new ArgumentSignature[currentDepth];
+  
     int idx = 0;
-    
     for (PairList.Node node : nodes) {
       SEXP value;
-      Symbol formalName = null;
+      Symbol formalName;
       if (matchedMap == null) {
         value = node.getValue().force(context);
       } else {
         formalName = node.getTag();
-        value = matchedMap.get(formalName).force(context);
-      }
-    
-      if(matchedMap != null && formalName == Symbols.ELLIPSES) {
-        break;
+        if(formalName != Symbols.ELLIPSES) {
+          value = matchedMap.get(formalName).force(context);
+        } else {
+          continue;
+        }
       }
       
       argSignatures[idx] = getArgumentSignature(context, value);

--- a/core/src/main/java/org/renjin/primitives/S3.java
+++ b/core/src/main/java/org/renjin/primitives/S3.java
@@ -435,22 +435,40 @@ public class S3 {
     }
   
     SelectedMethod method;
-    if(validMethods.get(0).size() == 0) {
-      // select closest group method if no generic methods are found
-      method = validMethods.get(1).get(0);
-    } else if(validMethods.get(1).size() == 0){
-      // select closest generic method if no group methods are found
-      method = validMethods.get(0).get(0);
-    } else {
+    if(validMethods.size() > 1) {
       // select closest group method if distance is less than the distance of closest generic method
-      int genericDistance = validMethods.get(0).get(0).getDistance();
-      int groupDistance = validMethods.get(1).get(0).getDistance();
-      if(groupDistance < genericDistance) {
+      int genericDistance = validMethods.get(0).size() == 0 ? -1 : validMethods.get(0).get(0).getDistance();
+      int groupDistance = validMethods.get(1).size() == 0 ? -1 : validMethods.get(1).get(0).getDistance();
+      if(genericDistance == -1 || (groupDistance != -1 && groupDistance < genericDistance)) {
         method = validMethods.get(1).get(0);
       } else {
         method = validMethods.get(0).get(0);
       }
+    } else {
+      if(validMethods.get(0).size() == 0) {
+        // select closest group method if no generic methods are found
+        method = validMethods.get(1).get(0);
+      } else {
+        // select closest generic method if no group methods are found
+        method = validMethods.get(0).get(0);
+      }
     }
+//    if(validMethods.get(0).size() == 0) {
+//      // select closest group method if no generic methods are found
+//      method = validMethods.get(1).get(0);
+//    } else if(validMethods.get(1).size() == 0){
+//      // select closest generic method if no group methods are found
+//      method = validMethods.get(0).get(0);
+//    } else {
+//      // select closest group method if distance is less than the distance of closest generic method
+//      int genericDistance = validMethods.get(0).get(0).getDistance();
+//      int groupDistance = validMethods.get(1).get(0).getDistance();
+//      if(groupDistance < genericDistance) {
+//        method = validMethods.get(1).get(0);
+//      } else {
+//        method = validMethods.get(0).get(0);
+//      }
+//    }
     
 //     if selected method is from Group or if its from standard generic but distance is > 0
 //     returned function environment is populated with the following metadata objects:

--- a/packages/methods/src/main/R/RMethodUtils.R
+++ b/packages/methods/src/main/R/RMethodUtils.R
@@ -356,6 +356,7 @@ conformMethod <- function(signature, mnames, fnames,
 
 rematchDefinition <- function(definition, generic, mnames, fnames, signature)
 {
+    cat(sprintf("definition: %s\n",deparse(definition)))
     added <- any(is.na(match(mnames, fnames)))
     keepsDots <- !is.na(match("...", mnames))
     if(!added && keepsDots) {

--- a/packages/methods/src/main/R/RMethodUtils.R
+++ b/packages/methods/src/main/R/RMethodUtils.R
@@ -356,7 +356,6 @@ conformMethod <- function(signature, mnames, fnames,
 
 rematchDefinition <- function(definition, generic, mnames, fnames, signature)
 {
-    cat(sprintf("definition: %s\n",deparse(definition)))
     added <- any(is.na(match(mnames, fnames)))
     keepsDots <- !is.na(match("...", mnames))
     if(!added && keepsDots) {

--- a/test-packages/s3test/src/main/R/s4methods.R
+++ b/test-packages/s3test/src/main/R/s4methods.R
@@ -30,10 +30,8 @@ setMethod('/', c("City", "character"), function(e1, e2) 351)
 setMethod('[', signature(x="City", i="numeric", j="missing"), function(x,i,j,...,drop) 400)
 
 setReplaceMethod('[[', c(x="City", i="ANY", j="missing", value="ANY"),
-  function(x,i,value) {
-    cat("inside setReplaceMethod befor assign\n")
+  function(x,i,j,value) {
     assign( i, value, x@.xData )
-    cat("inside setReplaceMethod after assign\n")
     return( x )
   }
 )

--- a/test-packages/s3test/src/test/R/test.R
+++ b/test-packages/s3test/src/test/R/test.R
@@ -41,6 +41,6 @@ assign( "a", 10, city@.xData )
 assign( "b", 120, city@.xData )
 assertThat(city@.xData$a, identicalTo(10))
 assertThat(city@.xData$b, identicalTo(120))
-city[["c"]] <- 150
-assertThat(city@.xData$c, identicalTo( 150 ))
-assertThat(city[["c"]], identicalTo( 150 ))
+city[["City"]] <- "Amsterdam"
+#assertThat(city@.xData$City, identicalTo( "Amsterdam" ))
+#assertThat(city[["City"]], identicalTo( "Amsterdam" ))

--- a/test-packages/s3test/src/test/R/test.R
+++ b/test-packages/s3test/src/test/R/test.R
@@ -42,5 +42,5 @@ assign( "b", 120, city@.xData )
 assertThat(city@.xData$a, identicalTo(10))
 assertThat(city@.xData$b, identicalTo(120))
 city[["City"]] <- "Amsterdam"
-#assertThat(city@.xData$City, identicalTo( "Amsterdam" ))
-#assertThat(city[["City"]], identicalTo( "Amsterdam" ))
+assertThat(city@.xData$City, identicalTo( "Amsterdam" ))
+assertThat(city[["City"]], identicalTo( "Amsterdam" ))

--- a/test-packages/s4test/src/test/R/test.s4.dispatch.environment.00.R
+++ b/test-packages/s4test/src/test/R/test.s4.dispatch.environment.00.R
@@ -29,25 +29,12 @@ setMethod("[[", c(x="B", i="missing", j="ANY"       ), function(x, i, ...)    2.
 setMethod("[[", c(x="B", j="missing", i="ANY"       ), function(x, i, ...)    2.58 )
 setMethod("[[", c(x="B", j="numeric", i="character" ), function(x, i, j, ...) 2.43 )
 setMethod("[[", c(x="B", i="numeric", j="character" ), function(x, i, j, ...) 2.55 )
-
-test.missing.env.01 = function() {
-    assertThat(b[[]] , identicalTo(2.4))
-}
-    test.missing.env.02 = function() {
-        assertThat(b[["a"]] , identicalTo(2.58))
-    }
-    test.missing.env.03 = function() {
-        assertThat(b[[1]] , identicalTo(2.58))
-    }
-test.missing.env.04 = function() {
-    assertThat(b[[,1]] , identicalTo(2.5))
-}
-    test.missing.env.05 = function() {
-        assertThat(b[[1.0,"c"]] , identicalTo(2.55))
-    }
-    test.missing.env.06 = function() {
-        assertThat(b[["c",1.0]] , identicalTo(2.43))
-    }
+test.missing.env.01 = function() { assertThat(b[[]] , identicalTo(2.4)) }
+test.missing.env.02 = function() { assertThat(b[["a"]] , identicalTo(2.58)) }
+test.missing.env.03 = function() { assertThat(b[[1]] , identicalTo(2.58)) }
+test.missing.env.04 = function() { assertThat(b[[,1]] , identicalTo(2.5)) }
+test.missing.env.05 = function() { assertThat(b[[1.0,"c"]] , identicalTo(2.55)) }
+test.missing.env.06 = function() { assertThat(b[["c",1.0]] , identicalTo(2.43)) }
 
 setClass("C", representation(a = "numeric"))
 c <- new("C", a = 100)
@@ -56,22 +43,9 @@ setMethod("[[", c(x="C", i="missing", j="ANY"       ), function(x, i, ...)    12
 setMethod("[[", c(x="C", j="missing", i="ANY"       ), function(x, i, ...)    12.58 )
 setMethod("[[", c(x="C", j="numeric", i="character" ), function(x, i, j, ...) 12.43 )
 setMethod("[[", c(x="C", i="numeric", j="character" ), function(x, i, j, ...) 12.55 )
-
-test.missing.std.01 = function() {
-    assertThat(c[[]] , identicalTo(12.4))
-}
-test.missing.std.02 = function() {
-    assertThat(c[["a"]] , identicalTo(12.58))
-}
-test.missing.std.03 = function() {
-    assertThat(c[[1]] , identicalTo(12.58))
-}
-test.missing.std.04 = function() {
-    assertThat(c[[,1]] , identicalTo(12.5))
-}
-test.missing.std.05 = function() {
-    assertThat(c[[1.0,"c"]] , identicalTo(12.55))
-}
-test.missing.std.06 = function() {
-    assertThat(c[["c",1.0]] , identicalTo(12.43))
-}
+test.missing.std.01 = function() { assertThat(c[[]] , identicalTo(12.4)) }
+test.missing.std.02 = function() { assertThat(c[["a"]] , identicalTo(12.58)) }
+test.missing.std.03 = function() { assertThat(c[[1]] , identicalTo(12.58)) }
+test.missing.std.04 = function() { assertThat(c[[,1]] , identicalTo(12.5)) }
+test.missing.std.05 = function() { assertThat(c[[1.0,"c"]] , identicalTo(12.55)) }
+test.missing.std.06 = function() { assertThat(c[["c",1.0]] , identicalTo(12.43)) }

--- a/test-packages/s4test/src/test/R/test.s4.dispatch.imported.01.R
+++ b/test-packages/s4test/src/test/R/test.s4.dispatch.imported.01.R
@@ -37,10 +37,13 @@ test.simple.update = function() {
     assertThat(es@temp, identicalTo("Hot!"))
 }
 
-test.imported.methods.extending.builtins = function() {
+test.imported.methods.extending.builtins1 = function() {
     assertThat(city[[]], identicalTo( 300 ))
-    city[["a"]]<-1
-    assertThat(city[["a"]], identicalTo( 1 ))
+}
+
+test.imported.methods.extending.builtins2 = function() {
+    city[["a"]] <- 1
+    assertThat(city[["a"]], identicalTo(1))
 }
 
 setMethod("-", c("City", "ANY"), function(e1, e2) 450)

--- a/test-packages/s4test/src/test/R/test.s4.dispatch.missing.01.R
+++ b/test-packages/s4test/src/test/R/test.s4.dispatch.missing.01.R
@@ -25,7 +25,7 @@ setClass("A", representation(a="numeric"))
 a <- new("A", a = 10)
 setMethod("[[", c(x="A", j="missing", i="missing"), function(x, ...)       1.4 )
 setMethod("[[", c(x="A", j="ANY",     i="ANY"    ), function(x, i, j, ...) 1.43)
-setMethod("[[", c(x="A", j="missing", i="A"      ), function(x, i, ...)    1.5 )
+setMethod("[[", c(x="A", j="missing", i="A"      ), function(x, i, j, ...)    1.5 )
 setMethod("[[", c(x="A", j="ANY",     i="A"      ), function(x, i, j, ...) 1.55)
 setMethod("[[", c(x="A", j="A",       i="missing"), function(x, j, ...)    1.6 )
 setMethod("[[", c(x="A", j="A",       i="ANY"    ), function(x, i, j, ...) 1.7 )
@@ -55,20 +55,90 @@ test.s4.missing.06 = function() {
     assertThat( a[[j=a,i=]] , identicalTo( 1.5 ))
 }
 
+test.s4.missing.07 = function() {
+    assertThat( a[[a,1]] , identicalTo( 1.55 ))
+}
+
+test.s4.missing.07b = function() {
+    assertThat( a[[j=a,i=1]] , identicalTo( 1.55 ))
+}
+
+test.s4.missing.08 = function() {
+    assertThat( a[[1,a]] , identicalTo( 1.7 ))
+}
+
+test.s4.missing.08b = function() {
+    assertThat( a[[j=1,i=a]] , identicalTo( 1.7 ))
+}
+
 
 setClass("B", representation(b = "numeric"))
 b <- new("B", b = 10)
 setMethod("[[", c(x = "B", i = "missing", j = "ANY"    ), function(x, j,    ...) 1.47)
 
-test.s4.missing.07 = function() {
+test.s4.missing.09 = function() {
     assertThat( b[[,1]] , identicalTo( 1.47 ))
 }
 
-test.s4.missing.08 = function() {
+test.s4.missing.10 = function() {
     assertThat( b[[]] , identicalTo( 1.47 ))
 }
 
-test.s4.missing.09 = function() {
+test.s4.missing.11 = function() {
     setMethod("[[", c(x = "B", i = "missing", j = "missing"), function(x,       ...) 1.46)
     assertThat( b[[]] , identicalTo( 1.46 ))
 }
+
+setClass("C", representation(c = "numeric"))
+c <- new("C", c = 10)
+setMethod("[[<-", c(x = "C", i = "C", j = "C", value = "C"    ), function(x, i, j,..., value) { x@c <- 1.001; x} )
+setMethod("[[<-", c(x = "C", i = "C", j = "C", value = "NULL"    ), function(x, i, j,..., value) { x@c <- 1.002; x} )
+setMethod("[[<-", c(x = "C", i = "C", j = "missing", value = "C"    ), function(x, i, j,..., value) { x@c <- 1.003; x} )
+setMethod("[[<-", c(x = "C", i = "C", j = "missing", value = "NULL"    ), function(x, i, j,..., value) { x@c <- 1.004; x} )
+
+test.s4.missing.12 = function() { assertThat( {c[[c,c]]<-c; c@c} , identicalTo( 1.001 )) }
+test.s4.missing.13 = function() { assertThat( {c[[c,c]]<-NULL; c@c} , identicalTo( 1.002 )) }
+test.s4.missing.14 = function() { assertThat( {c[[c,]]<-c; c@c} , identicalTo( 1.003 )) }
+test.s4.missing.15 = function() { assertThat( {c[[c,]]<-NULL; c@c} , identicalTo( 1.004 )) }
+
+
+
+setClass("D", representation(dval = "numeric"))
+d <- new("D", dval = 10)
+setMethod("[[<-", c(x = "D", i = "D", j = "missing", value = "D"    ), function(x, i,..., value) { x@dval <- 1.001; x} )
+setMethod("[[<-", c(x = "D", i = "D", j = "missing", value = "NULL"    ), function(x, i,..., value) { x@dval <- 1.002; x} )
+
+test.s4.missing.16 = function() { assertThat( {d[[d,]]<-d; d@dval} , identicalTo( 1.001 )) }
+test.s4.missing.18 = function() { assertThat( {d[[d]]<-d; d@dval} , identicalTo( 1.001 )) }
+test.s4.missing.17 = function() { assertThat( {d[[d,]]<-NULL; d@dval} , identicalTo( 1.002 )) }
+test.s4.missing.18 = function() { assertThat( {d[[j=d,i=]]<-NULL; d@dval} , identicalTo( 1.002 )) }
+test.s4.missing.20 = function() { assertThat( {d[[d]]<-NULL; d@dval} , identicalTo( 1.002 )) }
+
+
+
+setClass("G", representation(gval = "numeric"))
+g <- new("G", gval = 10)
+setMethod("[[<-", c(x = "G", i = "numeric", j = "missing", value = "character"    ), function(x, i,..., value) { x@gval <- 1.001; x} )
+setMethod("[[<-", c(x = "G", i = "numeric", j = "missing", value = "NULL"    ), function(x, i,..., value) { x@gval <- 1.002; x} )
+
+test.s4.missing.21 = function() { assertThat( {g[[1,]]<-"test"; g@gval} , identicalTo( 1.001 )) }
+test.s4.missing.22 = function() { assertThat( {g[[1,]]<-NULL; g@gval} , identicalTo( 1.002 )) }
+test.s4.missing.23 = function() { assertThat( {g[[1]]<-"test"; g@gval} , identicalTo( 1.001 )) }
+test.s4.missing.24 = function() { assertThat( {g[[1]]<-NULL; g@gval} , identicalTo( 1.002 )) }
+test.s4.missing.25 = function() { assertThat( {g[[j=1]]<-NULL; g@gval} , identicalTo( 1.002 )) }
+test.s4.missing.26 = function() { assertThat( {g[[j=1,i=]]<-NULL; g@gval} , identicalTo( 1.002 )) }
+
+library(hamcrest)
+
+setClass("H", representation(hval = "numeric"))
+h <- new("H", hval = 10)
+setMethod("[", c(x = "H", i = "numeric", j = "missing", drop = "character"    ), function(x, i,..., drop) 1.001 )
+setMethod("[", c(x = "H", i = "numeric", j = "missing", drop = "NULL"    ), function(x, i,..., drop) 1.002 )
+
+test.s4.missing.28 = function() { assertThat( h[1,,NULL] , identicalTo( 1.002 )) }
+test.s4.missing.30 = function() { assertThat( h[1,,NULL] , identicalTo( 1.002 )) }
+test.s4.missing.31 = function() { assertThat( h[j=1,,NULL] , identicalTo( 1.002 )) }
+test.s4.missing.32 = function() { assertThat( h[j=1,i=,NULL] , identicalTo( 1.002 )) }
+test.s4.missing.33 = function() { assertThat( h[1,,drop="test"] , identicalTo( 1.001 ) ) }
+test.s4.missing.34 = function() { assertThat( h[1,,drop="test"] , identicalTo( 1.001 ) ) }
+

--- a/test-packages/s4test/src/test/R/test.s4.dispatch.missing.01.R
+++ b/test-packages/s4test/src/test/R/test.s4.dispatch.missing.01.R
@@ -30,64 +30,23 @@ setMethod("[[", c(x="A", j="ANY",     i="A"      ), function(x, i, j, ...) 1.55)
 setMethod("[[", c(x="A", j="A",       i="missing"), function(x, j, ...)    1.6 )
 setMethod("[[", c(x="A", j="A",       i="ANY"    ), function(x, i, j, ...) 1.7 )
 setMethod("[[", c(x="A", i="A",       j="A"      ), function(x, i, j, ...) 1.8 )
-
-test.s4.missing.01 = function() {
-    assertThat( a[[]] , identicalTo( 1.4 ))
-}
-
-test.s4.missing.02 = function() {
-    assertThat( a[[a,a]] , identicalTo( 1.8 ))
-}
-
-test.s4.missing.03 = function() {
-    assertThat( a[[a,]] , identicalTo( 1.5 ))
-}
-
-test.s4.missing.04 = function() {
-    assertThat( a[[,a]] , identicalTo( 1.6 ))
-}
-
-test.s4.missing.05 = function() {
-    assertThat( a[[i=a,j=]] , identicalTo( 1.5 ))
-}
-
-test.s4.missing.06 = function() {
-    assertThat( a[[j=a,i=]] , identicalTo( 1.5 ))
-}
-
-test.s4.missing.07 = function() {
-    assertThat( a[[a,1]] , identicalTo( 1.55 ))
-}
-
-test.s4.missing.07b = function() {
-    assertThat( a[[j=a,i=1]] , identicalTo( 1.55 ))
-}
-
-test.s4.missing.08 = function() {
-    assertThat( a[[1,a]] , identicalTo( 1.7 ))
-}
-
-test.s4.missing.08b = function() {
-    assertThat( a[[j=1,i=a]] , identicalTo( 1.7 ))
-}
-
+test.s4.missing.01 = function() { assertThat( a[[]] , identicalTo( 1.4 )) }
+test.s4.missing.02 = function() { assertThat( a[[a,a]] , identicalTo( 1.8 )) }
+test.s4.missing.03 = function() { assertThat( a[[a,]] , identicalTo( 1.5 )) }
+test.s4.missing.04 = function() { assertThat( a[[,a]] , identicalTo( 1.6 )) }
+test.s4.missing.05 = function() { assertThat( a[[i=a,j=]] , identicalTo( 1.5 )) }
+ignore.test.s4.missing.06 = function() { assertThat( a[[j=a,i=]] , identicalTo( 1.5 )) }
+test.s4.missing.07 = function() { assertThat( a[[a,1]] , identicalTo( 1.55 )) }
+ignore.test.s4.missing.07b = function() { assertThat( a[[j=a,i=1]] , identicalTo( 1.55 )) }
+test.s4.missing.08 = function() { assertThat( a[[1,a]] , identicalTo( 1.7 )) }
+ignore.test.s4.missing.08b = function() { assertThat( a[[j=1,i=a]] , identicalTo( 1.7 )) }
 
 setClass("B", representation(b = "numeric"))
 b <- new("B", b = 10)
 setMethod("[[", c(x = "B", i = "missing", j = "ANY"    ), function(x, j,    ...) 1.47)
-
-test.s4.missing.09 = function() {
-    assertThat( b[[,1]] , identicalTo( 1.47 ))
-}
-
-test.s4.missing.10 = function() {
-    assertThat( b[[]] , identicalTo( 1.47 ))
-}
-
-test.s4.missing.11 = function() {
-    setMethod("[[", c(x = "B", i = "missing", j = "missing"), function(x,       ...) 1.46)
-    assertThat( b[[]] , identicalTo( 1.46 ))
-}
+test.s4.missing.09 = function() { assertThat( b[[,1]] , identicalTo( 1.47 )) }
+test.s4.missing.10 = function() { assertThat( b[[]] , identicalTo( 1.47 ))}
+test.s4.missing.11 = function() { setMethod("[[", c(x = "B", i = "missing", j = "missing"), function(x,       ...) 1.46); assertThat( b[[]] , identicalTo( 1.46 )) }
 
 setClass("C", representation(c = "numeric"))
 c <- new("C", c = 10)
@@ -95,50 +54,72 @@ setMethod("[[<-", c(x = "C", i = "C", j = "C", value = "C"    ), function(x, i, 
 setMethod("[[<-", c(x = "C", i = "C", j = "C", value = "NULL"    ), function(x, i, j,..., value) { x@c <- 1.002; x} )
 setMethod("[[<-", c(x = "C", i = "C", j = "missing", value = "C"    ), function(x, i, j,..., value) { x@c <- 1.003; x} )
 setMethod("[[<-", c(x = "C", i = "C", j = "missing", value = "NULL"    ), function(x, i, j,..., value) { x@c <- 1.004; x} )
-
 test.s4.missing.12 = function() { assertThat( {c[[c,c]]<-c; c@c} , identicalTo( 1.001 )) }
 test.s4.missing.13 = function() { assertThat( {c[[c,c]]<-NULL; c@c} , identicalTo( 1.002 )) }
 test.s4.missing.14 = function() { assertThat( {c[[c,]]<-c; c@c} , identicalTo( 1.003 )) }
 test.s4.missing.15 = function() { assertThat( {c[[c,]]<-NULL; c@c} , identicalTo( 1.004 )) }
 
-
-
 setClass("D", representation(dval = "numeric"))
 d <- new("D", dval = 10)
 setMethod("[[<-", c(x = "D", i = "D", j = "missing", value = "D"    ), function(x, i,..., value) { x@dval <- 1.001; x} )
 setMethod("[[<-", c(x = "D", i = "D", j = "missing", value = "NULL"    ), function(x, i,..., value) { x@dval <- 1.002; x} )
-
 test.s4.missing.16 = function() { assertThat( {d[[d,]]<-d; d@dval} , identicalTo( 1.001 )) }
-test.s4.missing.18 = function() { assertThat( {d[[d]]<-d; d@dval} , identicalTo( 1.001 )) }
+ignore.test.s4.missing.18 = function() { assertThat( {d[[d]]<-d; d@dval} , identicalTo( 1.001 )) }
 test.s4.missing.17 = function() { assertThat( {d[[d,]]<-NULL; d@dval} , identicalTo( 1.002 )) }
-test.s4.missing.18 = function() { assertThat( {d[[j=d,i=]]<-NULL; d@dval} , identicalTo( 1.002 )) }
+ignore.test.s4.missing.18 = function() { assertThat( {d[[j=d,i=]]<-NULL; d@dval} , identicalTo( 1.002 )) }
 test.s4.missing.20 = function() { assertThat( {d[[d]]<-NULL; d@dval} , identicalTo( 1.002 )) }
-
-
 
 setClass("G", representation(gval = "numeric"))
 g <- new("G", gval = 10)
 setMethod("[[<-", c(x = "G", i = "numeric", j = "missing", value = "character"    ), function(x, i,..., value) { x@gval <- 1.001; x} )
 setMethod("[[<-", c(x = "G", i = "numeric", j = "missing", value = "NULL"    ), function(x, i,..., value) { x@gval <- 1.002; x} )
-
 test.s4.missing.21 = function() { assertThat( {g[[1,]]<-"test"; g@gval} , identicalTo( 1.001 )) }
 test.s4.missing.22 = function() { assertThat( {g[[1,]]<-NULL; g@gval} , identicalTo( 1.002 )) }
 test.s4.missing.23 = function() { assertThat( {g[[1]]<-"test"; g@gval} , identicalTo( 1.001 )) }
 test.s4.missing.24 = function() { assertThat( {g[[1]]<-NULL; g@gval} , identicalTo( 1.002 )) }
-test.s4.missing.25 = function() { assertThat( {g[[j=1]]<-NULL; g@gval} , identicalTo( 1.002 )) }
-test.s4.missing.26 = function() { assertThat( {g[[j=1,i=]]<-NULL; g@gval} , identicalTo( 1.002 )) }
-
-library(hamcrest)
+ignore.test.s4.missing.25 = function() { assertThat( {g[[j=1]]<-NULL; g@gval} , identicalTo( 1.002 )) }
+ignore.test.s4.missing.26 = function() { assertThat( {g[[j=1,i=]]<-NULL; g@gval} , identicalTo( 1.002 )) }
 
 setClass("H", representation(hval = "numeric"))
 h <- new("H", hval = 10)
 setMethod("[", c(x = "H", i = "numeric", j = "missing", drop = "character"    ), function(x, i,..., drop) 1.001 )
 setMethod("[", c(x = "H", i = "numeric", j = "missing", drop = "NULL"    ), function(x, i,..., drop) 1.002 )
+ignore.test.s4.missing.27 = function() { assertThat( h[1,,NULL] , identicalTo( 1.002 )) }
+ignore.test.s4.missing.28 = function() { assertThat( h[1,,NULL] , identicalTo( 1.002 )) }
+ignore.test.s4.missing.29 = function() { assertThat( h[j=1,,NULL] , identicalTo( 1.002 )) }
+ignore.test.s4.missing.30 = function() { assertThat( h[j=1,i=,NULL] , identicalTo( 1.002 )) }
+test.s4.missing.31 = function() { assertThat( h[1,,drop="test"] , identicalTo( 1.001 ) ) }
+test.s4.missing.32 = function() { assertThat( h[1,,drop="test"] , identicalTo( 1.001 ) ) }
 
-test.s4.missing.28 = function() { assertThat( h[1,,NULL] , identicalTo( 1.002 )) }
-test.s4.missing.30 = function() { assertThat( h[1,,NULL] , identicalTo( 1.002 )) }
-test.s4.missing.31 = function() { assertThat( h[j=1,,NULL] , identicalTo( 1.002 )) }
-test.s4.missing.32 = function() { assertThat( h[j=1,i=,NULL] , identicalTo( 1.002 )) }
-test.s4.missing.33 = function() { assertThat( h[1,,drop="test"] , identicalTo( 1.001 ) ) }
-test.s4.missing.34 = function() { assertThat( h[1,,drop="test"] , identicalTo( 1.001 ) ) }
+
+setClass("city", contains = "environment")
+city <- new("city", new.env(hash = TRUE, parent = emptyenv()))
+setReplaceMethod("[[", c(x="city", i="character", j="missing", value="ANY"), function(x,i,value) { assign(i, value, x@.xData); x })
+setReplaceMethod("[[", c(x="city", i="character", j="missing", value="NULL"), function(x,i,value) { assign(i, value, x@.xData); x })
+setReplaceMethod("[[", c(x="city", i="missing", j="character", value="ANY"), function(x,j,value) { assign(j, value, x@.xData); x })
+setReplaceMethod("[[", c(x="city", i="missing", j="character", value="NULL"), function(x,j,value) { assign(j, value, x@.xData); x })
+
+ignore.test.s4.missing.33 = function() { assertThat( {city[["Name"]]<-"The Hague"; city@.xData$Name} , identicalTo( "The Hague" )) }
+ignore.test.s4.missing.34 = function() { assertThat( {city[["Name",]]<-NULL; city@.xData$Name} , identicalTo( NULL )) }
+ignore.test.s4.missing.35 = function() { assertThat( {city[[,"Country"]]<-"The Netherlands"; city@.xData$Country} , identicalTo( "The Netherlands" )) }
+ignore.test.s4.missing.36 = function() { assertThat( {assign("Country","Germany",city@.xData); city[[,"Country"]]<-NULL; city@.xData$Country} , identicalTo( NULL )) }
+
+
+setClass( 'City', contains = 'environment')
+city2 <- new("City", new.env(hash = TRUE, parent = emptyenv()))
+setReplaceMethod("[[", c(x="City", i="ANY", j="missing", value="ANY"), function(x,i,value) { assign(i, value, x@.xData); x })
+setReplaceMethod("[[", c(x="City", i="character", j="missing", value="NULL"), function(x,i,value) { assign(i, value, x@.xData); x })
+
+ignore.test.s4.missing.37 = function() {
+    assertThat( {                                          city2[["Name"]]<-"Amsterdam"; city2@.xData$Name } , identicalTo( "Amsterdam" ))
+}
+ignore.test.s4.missing.38 = function() {
+    assertThat( { assign("Name","Munich",city2@.xData);    city2[["Name", ]] <- "Amsterdam"; city2@.xData$Name } , identicalTo( "Amsterdam" ))
+}
+ignore.test.s4.missing.39 = function() {
+    assertThat( { assign("Name","Rotterdam",city2@.xData); city2[["Name", ]] <- NULL; city2@.xData$Name } , identicalTo( NULL ))
+}
+ignore.test.s4.missing.40 = function() {
+    assertThat( { assign("Name","Rotterdam",city2@.xData); city2[["Name"]] <- NULL; city2@.xData$Name } , identicalTo( NULL ))
+}
 

--- a/test-packages/s4test/src/test/R/test.s4.dispatch.missing.01.R
+++ b/test-packages/s4test/src/test/R/test.s4.dispatch.missing.01.R
@@ -35,11 +35,11 @@ test.s4.missing.02 = function() { assertThat( a[[a,a]] , identicalTo( 1.8 )) }
 test.s4.missing.03 = function() { assertThat( a[[a,]] , identicalTo( 1.5 )) }
 test.s4.missing.04 = function() { assertThat( a[[,a]] , identicalTo( 1.6 )) }
 test.s4.missing.05 = function() { assertThat( a[[i=a,j=]] , identicalTo( 1.5 )) }
-ignore.test.s4.missing.06 = function() { assertThat( a[[j=a,i=]] , identicalTo( 1.5 )) }
+test.s4.missing.06 = function() { assertThat( a[[j=a,i=]] , identicalTo( 1.5 )) }
 test.s4.missing.07 = function() { assertThat( a[[a,1]] , identicalTo( 1.55 )) }
-ignore.test.s4.missing.07b = function() { assertThat( a[[j=a,i=1]] , identicalTo( 1.55 )) }
+test.s4.missing.07b = function() { assertThat( a[[j=a,i=1]] , identicalTo( 1.55 )) }
 test.s4.missing.08 = function() { assertThat( a[[1,a]] , identicalTo( 1.7 )) }
-ignore.test.s4.missing.08b = function() { assertThat( a[[j=1,i=a]] , identicalTo( 1.7 )) }
+test.s4.missing.08b = function() { assertThat( a[[j=1,i=a]] , identicalTo( 1.7 )) }
 
 setClass("B", representation(b = "numeric"))
 b <- new("B", b = 10)
@@ -64,9 +64,9 @@ d <- new("D", dval = 10)
 setMethod("[[<-", c(x = "D", i = "D", j = "missing", value = "D"    ), function(x, i,..., value) { x@dval <- 1.001; x} )
 setMethod("[[<-", c(x = "D", i = "D", j = "missing", value = "NULL"    ), function(x, i,..., value) { x@dval <- 1.002; x} )
 test.s4.missing.16 = function() { assertThat( {d[[d,]]<-d; d@dval} , identicalTo( 1.001 )) }
-ignore.test.s4.missing.18 = function() { assertThat( {d[[d]]<-d; d@dval} , identicalTo( 1.001 )) }
+test.s4.missing.18 = function() { assertThat( {d[[d]]<-d; d@dval} , identicalTo( 1.001 )) }
 test.s4.missing.17 = function() { assertThat( {d[[d,]]<-NULL; d@dval} , identicalTo( 1.002 )) }
-ignore.test.s4.missing.18 = function() { assertThat( {d[[j=d,i=]]<-NULL; d@dval} , identicalTo( 1.002 )) }
+test.s4.missing.18 = function() { assertThat( {d[[j=d,i=]]<-NULL; d@dval} , identicalTo( 1.002 )) }
 test.s4.missing.20 = function() { assertThat( {d[[d]]<-NULL; d@dval} , identicalTo( 1.002 )) }
 
 setClass("G", representation(gval = "numeric"))
@@ -77,49 +77,16 @@ test.s4.missing.21 = function() { assertThat( {g[[1,]]<-"test"; g@gval} , identi
 test.s4.missing.22 = function() { assertThat( {g[[1,]]<-NULL; g@gval} , identicalTo( 1.002 )) }
 test.s4.missing.23 = function() { assertThat( {g[[1]]<-"test"; g@gval} , identicalTo( 1.001 )) }
 test.s4.missing.24 = function() { assertThat( {g[[1]]<-NULL; g@gval} , identicalTo( 1.002 )) }
-ignore.test.s4.missing.25 = function() { assertThat( {g[[j=1]]<-NULL; g@gval} , identicalTo( 1.002 )) }
-ignore.test.s4.missing.26 = function() { assertThat( {g[[j=1,i=]]<-NULL; g@gval} , identicalTo( 1.002 )) }
+test.s4.missing.25 = function() { assertThat( {g[[1,]]<-NULL; g@gval} , identicalTo( 1.002 )) }
+test.s4.missing.26 = function() { assertThat( {g[[j=1,i=]]<-NULL; g@gval} , identicalTo( 1.002 )) }
 
 setClass("H", representation(hval = "numeric"))
 h <- new("H", hval = 10)
 setMethod("[", c(x = "H", i = "numeric", j = "missing", drop = "character"    ), function(x, i,..., drop) 1.001 )
 setMethod("[", c(x = "H", i = "numeric", j = "missing", drop = "NULL"    ), function(x, i,..., drop) 1.002 )
-ignore.test.s4.missing.27 = function() { assertThat( h[1,,NULL] , identicalTo( 1.002 )) }
-ignore.test.s4.missing.28 = function() { assertThat( h[1,,NULL] , identicalTo( 1.002 )) }
-ignore.test.s4.missing.29 = function() { assertThat( h[j=1,,NULL] , identicalTo( 1.002 )) }
-ignore.test.s4.missing.30 = function() { assertThat( h[j=1,i=,NULL] , identicalTo( 1.002 )) }
+test.s4.missing.27 = function() { assertThat( h[1,,NULL] , identicalTo( 1.002 )) }
+test.s4.missing.28 = function() { assertThat( h[1,,NULL] , identicalTo( 1.002 )) }
+test.s4.missing.29 = function() { assertThat( h[j=1,,NULL] , identicalTo( 1.002 )) }
+test.s4.missing.30 = function() { assertThat( h[j=1,i=,NULL] , identicalTo( 1.002 )) }
 test.s4.missing.31 = function() { assertThat( h[1,,drop="test"] , identicalTo( 1.001 ) ) }
 test.s4.missing.32 = function() { assertThat( h[1,,drop="test"] , identicalTo( 1.001 ) ) }
-
-
-setClass("city", contains = "environment")
-city <- new("city", new.env(hash = TRUE, parent = emptyenv()))
-setReplaceMethod("[[", c(x="city", i="character", j="missing", value="ANY"), function(x,i,value) { assign(i, value, x@.xData); x })
-setReplaceMethod("[[", c(x="city", i="character", j="missing", value="NULL"), function(x,i,value) { assign(i, value, x@.xData); x })
-setReplaceMethod("[[", c(x="city", i="missing", j="character", value="ANY"), function(x,j,value) { assign(j, value, x@.xData); x })
-setReplaceMethod("[[", c(x="city", i="missing", j="character", value="NULL"), function(x,j,value) { assign(j, value, x@.xData); x })
-
-ignore.test.s4.missing.33 = function() { assertThat( {city[["Name"]]<-"The Hague"; city@.xData$Name} , identicalTo( "The Hague" )) }
-ignore.test.s4.missing.34 = function() { assertThat( {city[["Name",]]<-NULL; city@.xData$Name} , identicalTo( NULL )) }
-ignore.test.s4.missing.35 = function() { assertThat( {city[[,"Country"]]<-"The Netherlands"; city@.xData$Country} , identicalTo( "The Netherlands" )) }
-ignore.test.s4.missing.36 = function() { assertThat( {assign("Country","Germany",city@.xData); city[[,"Country"]]<-NULL; city@.xData$Country} , identicalTo( NULL )) }
-
-
-setClass( 'City', contains = 'environment')
-city2 <- new("City", new.env(hash = TRUE, parent = emptyenv()))
-setReplaceMethod("[[", c(x="City", i="ANY", j="missing", value="ANY"), function(x,i,value) { assign(i, value, x@.xData); x })
-setReplaceMethod("[[", c(x="City", i="character", j="missing", value="NULL"), function(x,i,value) { assign(i, value, x@.xData); x })
-
-ignore.test.s4.missing.37 = function() {
-    assertThat( {                                          city2[["Name"]]<-"Amsterdam"; city2@.xData$Name } , identicalTo( "Amsterdam" ))
-}
-ignore.test.s4.missing.38 = function() {
-    assertThat( { assign("Name","Munich",city2@.xData);    city2[["Name", ]] <- "Amsterdam"; city2@.xData$Name } , identicalTo( "Amsterdam" ))
-}
-ignore.test.s4.missing.39 = function() {
-    assertThat( { assign("Name","Rotterdam",city2@.xData); city2[["Name", ]] <- NULL; city2@.xData$Name } , identicalTo( NULL ))
-}
-ignore.test.s4.missing.40 = function() {
-    assertThat( { assign("Name","Rotterdam",city2@.xData); city2[["Name"]] <- NULL; city2@.xData$Name } , identicalTo( NULL ))
-}
-

--- a/test-packages/s4test/src/test/R/test.s4.group.dispatch.02.R
+++ b/test-packages/s4test/src/test/R/test.s4.group.dispatch.02.R
@@ -1,0 +1,41 @@
+#
+# Renjin : JVM-based interpreter for the R language for the statistical analysis
+# Copyright © 2010-2016 BeDataDriven Groep B.V. and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, a copy is available at
+# https://www.gnu.org/licenses/gpl-2.0.txt
+#
+
+library(hamcrest)
+library(methods)
+
+setClass("A",representation(a="numeric"))
+setClass("B",contains="A")
+setClass("C",contains="B")
+setMethod("+",signature(e1="A",e2="A"),function(e1,e2) 101)
+setMethod("Arith",signature(e1="B",e2="B"), function(e1,e2) 102)
+
+c=new("C",a=10)
+a=new("A",a=12)
+
+test.group.dispatch2.1 = function() { assertThat(c+c, identicalTo(102) ) }
+test.group.dispatch2.2 = function() { assertThat(a+a, identicalTo(101) ) }
+
+
+setClass("AA",representation(a="numeric"))
+setClass("BB",contains="AA")
+setMethod("+",signature(e1="AA",e2="AA"),function(e1,e2) 101)
+setMethod("Arith",signature(e1="AA",e2="AA"), function(e1,e2) 102)
+aa=new("AA",a=12)
+test.group.dispatch2.3 = function() { assertThat(aa+aa, identicalTo(101) ) }

--- a/test-packages/s4test/src/test/R/test.s4.group.dispatch.02.R
+++ b/test-packages/s4test/src/test/R/test.s4.group.dispatch.02.R
@@ -39,3 +39,10 @@ setMethod("+",signature(e1="AA",e2="AA"),function(e1,e2) 101)
 setMethod("Arith",signature(e1="AA",e2="AA"), function(e1,e2) 102)
 aa=new("AA",a=12)
 test.group.dispatch2.3 = function() { assertThat(aa+aa, identicalTo(101) ) }
+
+
+setClass("AAA",representation(a="numeric"))
+setClass("BBB",contains="AAA")
+setMethod("Arith",signature(e1="AAA",e2="AAA"), function(e1,e2) 102)
+aaa=new("AAA",a=12)
+test.group.dispatch2.4 = function() { assertThat(aaa+aaa, identicalTo(102) ) }

--- a/test-packages/s4test/src/test/R/test.s4.local.R
+++ b/test-packages/s4test/src/test/R/test.s4.local.R
@@ -1,0 +1,54 @@
+#
+# Renjin : JVM-based interpreter for the R language for the statistical analysis
+# Copyright © 2010-2016 BeDataDriven Groep B.V. and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, a copy is available at
+# https://www.gnu.org/licenses/gpl-2.0.txt
+#
+
+library(hamcrest)
+library(methods)
+
+
+# These test currently fail due to incorrect formals of .local()
+# methods package needs to
+
+setClass("city", contains = "environment")
+city <- new("city", new.env(hash = TRUE, parent = emptyenv()))
+setReplaceMethod("[[", c(x="city", i="character", j="missing", value="ANY"), function(x,i,value) { assign(i, value, x@.xData); x })
+setReplaceMethod("[[", c(x="city", i="character", j="missing", value="NULL"), function(x,i,value) { assign(i, value, x@.xData); x })
+setReplaceMethod("[[", c(x="city", i="missing", j="character", value="ANY"), function(x,j,value) { assign(j, value, x@.xData); x })
+setReplaceMethod("[[", c(x="city", i="missing", j="character", value="NULL"), function(x,j,value) { assign(j, value, x@.xData); x })
+ignore.test.s4.local.01 = function() { assertThat( {city[["Name"]]<-"The Hague"; city@.xData$Name} , identicalTo( "The Hague" )) }
+ignore.test.s4.local.02 = function() { assertThat( {city[["Name",]]<-NULL; city@.xData$Name} , identicalTo( NULL )) }
+ignore.test.s4.local.03 = function() { assertThat( {city[[,"Country"]]<-"The Netherlands"; city@.xData$Country} , identicalTo( "The Netherlands" )) }
+ignore.test.s4.local.04 = function() { assertThat( {assign("Country","Germany",city@.xData); city[[,"Country"]]<-NULL; city@.xData$Country} , identicalTo( NULL )) }
+
+
+setClass( 'City', contains = 'environment')
+city2 <- new("City", new.env(hash = TRUE, parent = emptyenv()))
+setReplaceMethod("[[", c(x="City", i="ANY", j="missing", value="ANY"), function(x,i,value) { assign(i, value, x@.xData); x })
+setReplaceMethod("[[", c(x="City", i="character", j="missing", value="NULL"), function(x,i,value) { assign(i, value, x@.xData); x })
+ignore.test.s4.local.05 = function() {
+    assertThat( {                                          city2[["Name"]]<-"Amsterdam"; city2@.xData$Name } , identicalTo( "Amsterdam" ))
+}
+ignore.test.s4.local.06 = function() {
+    assertThat( { assign("Name","Munich",city2@.xData);    city2[["Name", ]] <- "Amsterdam"; city2@.xData$Name } , identicalTo( "Amsterdam" ))
+}
+ignore.test.s4.local.07 = function() {
+    assertThat( { assign("Name","Rotterdam",city2@.xData); city2[["Name", ]] <- NULL; city2@.xData$Name } , identicalTo( NULL ))
+}
+ignore.test.s4.local.08 = function() {
+    assertThat( { assign("Name","Rotterdam",city2@.xData); city2[["Name"]] <- NULL; city2@.xData$Name } , identicalTo( NULL ))
+}


### PR DESCRIPTION
Handle cases where:
* used arguments have different order than function formals or only a subset of formals are used for signature.

* function call and formals (excl ...) have the same length.

Not handeling cases where:
* signature contains "missing" and function is lacking the "missing" argument.
```
setMethod("[[", signature(x=A, i=missing, j=A), function(x,j) DO_SOMETHING)
a = new("A")
a[[a]]
```