### PR TITLE
recycling vectors are returning underlying values at index % baselength

### DIFF
--- a/core/src/main/java/org/renjin/sexp/RecyclingComplexVector.java
+++ b/core/src/main/java/org/renjin/sexp/RecyclingComplexVector.java
@@ -1,0 +1,58 @@
+/**
+ * Renjin : JVM-based interpreter for the R language for the statistical analysis
+ * Copyright © 2010-2016 BeDataDriven Groep B.V. and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, a copy is available at
+ * https://www.gnu.org/licenses/gpl-2.0.txt
+ */
+package org.renjin.sexp;
+
+import org.apache.commons.math.complex.Complex;
+
+public class RecyclingComplexVector extends ComplexVector implements RecyclingVector {
+  private int length;
+  private int baseLength;
+  private ComplexVector underlying;
+
+  public RecyclingComplexVector(int length, ComplexVector recycled) {
+    this(length, recycled, recycled.getAttributes());
+  }
+
+  private RecyclingComplexVector(int length, ComplexVector recycled, AttributeMap attributes) {
+    super(attributes);
+    this.length = length;
+    this.underlying = recycled;
+    this.baseLength = recycled.length();
+  }
+
+  @Override
+  public Complex getElementAsComplex(int index) {
+    return underlying.getElementAsComplex(index % baseLength);
+  }
+
+  @Override
+  public boolean isConstantAccessTime() {
+    return underlying.isConstantAccessTime();
+  }
+
+  @Override
+  public int length() {
+    return length;
+  }
+
+  @Override
+  protected SEXP cloneWithNewAttributes(AttributeMap attributes) {
+    return new RecyclingComplexVector(length, underlying, attributes);
+  }
+}

--- a/core/src/main/java/org/renjin/sexp/RecyclingDoubleVector.java
+++ b/core/src/main/java/org/renjin/sexp/RecyclingDoubleVector.java
@@ -1,0 +1,56 @@
+/**
+ * Renjin : JVM-based interpreter for the R language for the statistical analysis
+ * Copyright © 2010-2016 BeDataDriven Groep B.V. and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, a copy is available at
+ * https://www.gnu.org/licenses/gpl-2.0.txt
+ */
+package org.renjin.sexp;
+
+public class RecyclingDoubleVector extends DoubleVector implements RecyclingVector {
+  private int length;
+  private int baseLength;
+  private DoubleVector underlying;
+
+  public RecyclingDoubleVector(int length, DoubleVector recycled) {
+    this(length, recycled, recycled.getAttributes());
+  }
+
+  private RecyclingDoubleVector(int length, DoubleVector recycled, AttributeMap attributes) {
+    super(attributes);
+    this.length = length;
+    this.underlying = recycled;
+    this.baseLength = recycled.length();
+  }
+
+  @Override
+  public double getElementAsDouble(int index) {
+    return underlying.getElementAsDouble(index % baseLength);
+  }
+
+  @Override
+  public boolean isConstantAccessTime() {
+    return underlying.isConstantAccessTime();
+  }
+
+  @Override
+  public int length() {
+    return length;
+  }
+
+  @Override
+  protected SEXP cloneWithNewAttributes(AttributeMap attributes) {
+    return new RecyclingDoubleVector(length, underlying, attributes);
+  }
+}

--- a/core/src/main/java/org/renjin/sexp/RecyclingIntVector.java
+++ b/core/src/main/java/org/renjin/sexp/RecyclingIntVector.java
@@ -1,0 +1,56 @@
+/**
+ * Renjin : JVM-based interpreter for the R language for the statistical analysis
+ * Copyright © 2010-2016 BeDataDriven Groep B.V. and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, a copy is available at
+ * https://www.gnu.org/licenses/gpl-2.0.txt
+ */
+package org.renjin.sexp;
+
+public class RecyclingIntVector extends IntVector implements RecyclingVector {
+  private int length;
+  private int baseLength;
+  private IntVector underlying;
+
+  public RecyclingIntVector(int length, IntVector recycled) {
+    this(length, recycled, recycled.getAttributes());
+  }
+
+  private RecyclingIntVector(int length, IntVector recycled, AttributeMap attributes) {
+    super(attributes);
+    this.length = length;
+    this.underlying = recycled;
+    this.baseLength = recycled.length();
+  }
+
+  @Override
+  public int getElementAsInt(int index) {
+    return underlying.getElementAsInt(index % baseLength);
+  }
+
+  @Override
+  public boolean isConstantAccessTime() {
+    return underlying.isConstantAccessTime();
+  }
+
+  @Override
+  public int length() {
+    return length;
+  }
+
+  @Override
+  protected SEXP cloneWithNewAttributes(AttributeMap attributes) {
+    return new RecyclingIntVector(length, underlying, attributes);
+  }
+}

--- a/core/src/main/java/org/renjin/sexp/RecyclingLogicalVector.java
+++ b/core/src/main/java/org/renjin/sexp/RecyclingLogicalVector.java
@@ -1,0 +1,61 @@
+/**
+ * Renjin : JVM-based interpreter for the R language for the statistical analysis
+ * Copyright © 2010-2016 BeDataDriven Groep B.V. and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, a copy is available at
+ * https://www.gnu.org/licenses/gpl-2.0.txt
+ */
+package org.renjin.sexp;
+
+public class RecyclingLogicalVector extends LogicalVector implements RecyclingVector {
+  private int length;
+  private int baseLength;
+  private LogicalVector underlying;
+
+  public RecyclingLogicalVector(int length, LogicalVector recycled) {
+    this(length, recycled, recycled.getAttributes());
+  }
+
+  private RecyclingLogicalVector(int length, LogicalVector recycled, AttributeMap attributes) {
+    super(attributes);
+    this.length = length;
+    this.underlying = recycled;
+    this.baseLength = recycled.length();
+  }
+
+  @Override
+  public Logical getElementAsLogical(int index) {
+    return underlying.getElementAsLogical(index % baseLength);
+  }
+
+  @Override
+  public int getElementAsRawLogical(int index) {
+    return underlying.getElementAsRawLogical(index % baseLength);
+  }
+
+  @Override
+  public boolean isConstantAccessTime() {
+    return underlying.isConstantAccessTime();
+  }
+
+  @Override
+  public int length() {
+    return length;
+  }
+
+  @Override
+  protected SEXP cloneWithNewAttributes(AttributeMap attributes) {
+    return new RecyclingLogicalVector(length, underlying, attributes);
+  }
+}

--- a/core/src/main/java/org/renjin/sexp/RecyclingStringVector.java
+++ b/core/src/main/java/org/renjin/sexp/RecyclingStringVector.java
@@ -1,0 +1,56 @@
+/**
+ * Renjin : JVM-based interpreter for the R language for the statistical analysis
+ * Copyright © 2010-2016 BeDataDriven Groep B.V. and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, a copy is available at
+ * https://www.gnu.org/licenses/gpl-2.0.txt
+ */
+package org.renjin.sexp;
+
+public class RecyclingStringVector extends StringVector implements RecyclingVector {
+  private int length;
+  private int baseLength;
+  private StringVector underlying;
+
+  public RecyclingStringVector(int length, StringVector recycled) {
+    this(length, recycled, recycled.getAttributes());
+  }
+
+  private RecyclingStringVector(int length, StringVector recycled, AttributeMap attributes) {
+    super(attributes);
+    this.length = length;
+    this.underlying = recycled;
+    this.baseLength = recycled.length();
+  }
+
+  @Override
+  public String getElementAsString(int index) {
+    return underlying.getElementAsString(index % baseLength);
+  }
+
+  @Override
+  public boolean isConstantAccessTime() {
+    return underlying.isConstantAccessTime();
+  }
+
+  @Override
+  public int length() {
+    return length;
+  }
+
+  @Override
+  protected StringVector cloneWithNewAttributes(AttributeMap attributes) {
+    return new RecyclingStringVector(length, underlying, attributes);
+  }
+}

--- a/core/src/main/java/org/renjin/sexp/RecyclingVector.java
+++ b/core/src/main/java/org/renjin/sexp/RecyclingVector.java
@@ -1,0 +1,23 @@
+/**
+ * Renjin : JVM-based interpreter for the R language for the statistical analysis
+ * Copyright © 2010-2016 BeDataDriven Groep B.V. and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, a copy is available at
+ * https://www.gnu.org/licenses/gpl-2.0.txt
+ */
+package org.renjin.sexp;
+
+public interface RecyclingVector extends AtomicVector {
+
+}

--- a/core/src/test/java/org/renjin/sexp/RecyclingVectorTest.java
+++ b/core/src/test/java/org/renjin/sexp/RecyclingVectorTest.java
@@ -1,0 +1,74 @@
+/**
+ * Renjin : JVM-based interpreter for the R language for the statistical analysis
+ * Copyright © 2010-2016 BeDataDriven Groep B.V. and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, a copy is available at
+ * https://www.gnu.org/licenses/gpl-2.0.txt
+ */
+package org.renjin.sexp;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.apache.commons.math.complex.Complex;
+import org.junit.Test;
+
+public class RecyclingVectorTest {
+
+  @Test
+  public void recyclingComplexVector() {
+    Complex[] array = new Complex[] { ComplexVector.complex(0, 1), ComplexVector.complex(1, 2) };
+    ComplexVector base = new ComplexArrayVector(array);
+    ComplexVector recycling = new RecyclingComplexVector(5, base);
+    assertThat(recycling.length(), equalTo(5));
+    assertThat(recycling.getElementAsComplex(3), equalTo(ComplexVector.complex(1, 2)));
+  }
+
+  @Test
+  public void recyclingDoubleVector() {
+    double[] array = new double[] { 0.1, 1.2 };
+    DoubleVector base = new DoubleArrayVector(array);
+    DoubleVector recycling = new RecyclingDoubleVector(5, base);
+    assertThat(recycling.length(), equalTo(5));
+    assertThat(recycling.getElementAsDouble(3), equalTo(1.2));
+  }
+
+  @Test
+  public void recyclingIntVector() {
+    int[] array = new int[] { 0, 1 };
+    IntVector base = new IntArrayVector(array);
+    IntVector recycling = new RecyclingIntVector(5, base);
+    assertThat(recycling.length(), equalTo(5));
+    assertThat(recycling.getElementAsInt(3), equalTo(1));
+  }
+
+  @Test
+  public void recyclingLogicalVector() {
+    boolean[] array = new boolean[] { false, true };
+    LogicalVector base = new LogicalArrayVector(array);
+    LogicalVector recycling = new RecyclingLogicalVector(5, base);
+    assertThat(recycling.length(), equalTo(5));
+    assertThat(recycling.getElementAsLogical(3), equalTo(LogicalVector.TRUE.asLogical()));
+  }
+
+  @Test
+  public void recyclingStringVector() {
+    String[] array = new String[] { "0.1", "1.2" };
+    StringVector base = new StringArrayVector(array);
+    StringVector recycling = new RecyclingStringVector(5, base);
+    assertThat(recycling.length(), equalTo(5));
+    assertThat(recycling.getElementAsString(3), equalTo("1.2"));
+  }
+
+}


### PR DESCRIPTION
Recycling vectors are pretending to have the given length, while delegating methods `getElementAs<TYPE>` to the underlying vector they are wrapping, using modulo indexing.