### PR TITLE
implement Rf_iPsort required by expss dependencies

### DIFF
--- a/tools/gnur-runtime/src/main/java/org/renjin/gnur/Sort.java
+++ b/tools/gnur-runtime/src/main/java/org/renjin/gnur/Sort.java
@@ -20,6 +20,8 @@ package org.renjin.gnur;
 
 
 import org.renjin.gcc.runtime.DoublePtr;
+import org.renjin.gcc.runtime.IntPtr;
+import org.renjin.sexp.IntVector;
 
 import java.util.Arrays;
 
@@ -33,6 +35,35 @@ public class Sort {
    * larger to right
    *
    */
+  public static void iPsort2(IntPtr x, int lo, int hi, int k) {
+    boolean nalast = true;
+    int v, w;
+    int L, R, i, j;
+
+    for (L = lo, R = hi; L < R;) {
+      v = x.getInt(k);
+      for (i = L, j = R; i <= j;) {
+        while (icmp(x.getInt(i), v, nalast) < 0) {
+          i++;
+        }
+        while (icmp(v, x.getInt(j), nalast) < 0) {
+          j--;
+        }
+        if (i <= j) {
+          w = x.getInt(i);
+          x.setInt(i++, x.getInt(j));
+          x.setInt(j--, w);
+        }
+      }
+      if (j < k) {
+        L = i;
+      }
+      if (k < i) {
+        R = j;
+      }
+    }
+  }
+
   public static void rPsort2(DoublePtr x, int lo, int hi, int k) {
     boolean nalast=true;
     double v, w;
@@ -62,12 +93,40 @@ public class Sort {
     }
   }
 
+  public static void Rf_iPsort(IntPtr x, int n, int k) {
+    iPsort2(x, 0, n - 1, k);
+  }
+
   public static void Rf_rPsort(DoublePtr x, int n, int k) {
     rPsort2(x, 0, n-1, k);
   }
 
+  public static void R_isort(IntPtr x, int n) {
+    Arrays.sort(x.array, x.offset, x.offset + n);
+  }
+
   public static void R_rsort(DoublePtr x, int n) {
     Arrays.sort(x.array, x.offset, x.offset+n);
+  }
+
+  private static int icmp(int x, int y, boolean nalast) {
+    boolean nax = IntVector.isNA(x), nay = IntVector.isNA(y);
+    if (nax && nay) {
+      return 0;
+    }
+    if (nax) {
+      return nalast ? 1 : -1;
+    }
+    if (nay) {
+      return nalast ? -1 : 1;
+    }
+    if (x < y) {
+      return -1;
+    }
+    if (x > y) {
+      return 1;
+    }
+    return 0;
   }
 
   private static int rcmp(double x, double y, boolean nalast) {

--- a/tools/gnur-runtime/src/main/java/org/renjin/gnur/Sort.java
+++ b/tools/gnur-runtime/src/main/java/org/renjin/gnur/Sort.java
@@ -18,9 +18,10 @@
  */
 package org.renjin.gnur;
 
-
 import org.renjin.gcc.runtime.DoublePtr;
 import org.renjin.gcc.runtime.IntPtr;
+import org.renjin.gcc.runtime.Ptr;
+import org.renjin.sexp.DoubleVector;
 import org.renjin.sexp.IntVector;
 
 import java.util.Arrays;
@@ -35,7 +36,7 @@ public class Sort {
    * larger to right
    *
    */
-  public static void iPsort2(IntPtr x, int lo, int hi, int k) {
+  public static void iPsort2(Ptr x, int lo, int hi, int k) {
     boolean nalast = true;
     int v, w;
     int L, R, i, j;
@@ -64,24 +65,24 @@ public class Sort {
     }
   }
 
-  public static void rPsort2(DoublePtr x, int lo, int hi, int k) {
+  public static void rPsort2(Ptr x, int lo, int hi, int k) {
     boolean nalast=true;
     double v, w;
     int L, R, i, j;
 
     for (L = lo, R = hi; L < R; ) {
-      v = x.get(k);
+      v = x.getDouble(k);
       for(i = L, j = R; i <= j;) {
-        while (rcmp(x.get(i), v, nalast) < 0) {
+        while (rcmp(x.getDouble(i), v, nalast) < 0) {
           i++;
         }
-        while (rcmp(v, x.get(j), nalast) < 0) {
+        while (rcmp(v, x.getDouble(j), nalast) < 0) {
           j--;
         }
         if (i <= j) {
-          w = x.get(i);
-          x.set(i++, x.get(j));
-          x.set(j--,  w);
+          w = x.getDouble(i);
+          x.setDouble(i++, x.getDouble(j));
+          x.setDouble(j--, w);
         }
       }
       if (j < k) {
@@ -93,11 +94,11 @@ public class Sort {
     }
   }
 
-  public static void Rf_iPsort(IntPtr x, int n, int k) {
+  public static void Rf_iPsort(Ptr x, int n, int k) {
     iPsort2(x, 0, n - 1, k);
   }
 
-  public static void Rf_rPsort(DoublePtr x, int n, int k) {
+  public static void Rf_rPsort(Ptr x, int n, int k) {
     rPsort2(x, 0, n-1, k);
   }
 
@@ -130,7 +131,7 @@ public class Sort {
   }
 
   private static int rcmp(double x, double y, boolean nalast) {
-    boolean nax = Double.isNaN(x), nay = Double.isNaN(y);
+    boolean nax = DoubleVector.isNA(x), nay = DoubleVector.isNA(y);
     if (nax && nay) {
       return 0;
     }

--- a/tools/gnur-runtime/src/main/java/org/renjin/gnur/api/Utils.java
+++ b/tools/gnur-runtime/src/main/java/org/renjin/gnur/api/Utils.java
@@ -33,11 +33,11 @@ public final class Utils {
 
 
   public static void R_isort(IntPtr p0, int p1) {
-    throw new UnimplementedGnuApiMethod("R_isort");
+    org.renjin.gnur.Sort.R_isort(p0, p1);
   }
 
   public static void R_rsort(DoublePtr p0, int p1) {
-    throw new UnimplementedGnuApiMethod("R_rsort");
+    org.renjin.gnur.Sort.R_rsort(p0, p1);
   }
 
   // void R_csort (Rcomplex *, int)
@@ -51,7 +51,7 @@ public final class Utils {
   }
 
   public static void Rf_iPsort(IntPtr p0, int p1, int p2) {
-    throw new UnimplementedGnuApiMethod("Rf_iPsort");
+    org.renjin.gnur.Sort.Rf_iPsort(p0, p1, p2);
   }
 
   public static void Rf_rPsort(DoublePtr p0, int p1, int p2) {


### PR DESCRIPTION
The code looks a lot like copy-paste, because original C code uses macros to only change the name of the comparison method.

Using Java8 functions and wrapping all primitive types into objects is not an option when considering performance.