### PR TITLE
Null implementation of Sys.localeconv for expss dependencies  

### DIFF
--- a/core/src/main/java/org/renjin/primitives/Primitives.java
+++ b/core/src/main/java/org/renjin/primitives/Primitives.java
@@ -827,7 +827,7 @@ public class Primitives {
     f("Sys.sleep", System.class, 11);
     f("Sys.getlocale", System.class, 11);
     f("Sys.setlocale", System.class, 11);
-    f("Sys.localeconv", /*localeconv*/ null, 11);
+    f("Sys.localeconv", System.class, 11);
     f("path.expand", Files.class, "pathExpand", 11);
     f("Sys.getpid",System.class, 11);
     f("normalizePath", Files.class, 11);

--- a/core/src/main/java/org/renjin/primitives/System.java
+++ b/core/src/main/java/org/renjin/primitives/System.java
@@ -162,6 +162,32 @@ public class System {
     java.lang .System.out.println("locale = " + locale);
     return "";
   }
+  
+
+  /**
+   * A character vector with 18 named components.
+   * 
+   * The results in the C locale are
+   * 
+   * <pre>
+   * ##    decimal_point     thousands_sep          grouping   int_curr_symbol
+   * ##              "."                ""                ""                ""
+   * ##  currency_symbol mon_decimal_point mon_thousands_sep      mon_grouping
+   * ##               ""                ""                ""                ""
+   * ##    positive_sign     negative_sign   int_frac_digits       frac_digits
+   * ##               ""                ""             "127"             "127"
+   * ##    p_cs_precedes    p_sep_by_space     n_cs_precedes    n_sep_by_space
+   * ##            "127"             "127"             "127"             "127"
+   * ##      p_sign_posn       n_sign_posn
+   * ##            "127"             "127"
+   * </pre>
+   * 
+   * @return It is possible to compile R without support for locales, in which case the value will be <code>NULL</code>.
+   */
+  @Internal("Sys.localeconv")
+  public static Vector getLocaleConventions() {
+    return Null.INSTANCE;
+  }
 
   @Internal
   public static StringVector commandArgs(@Current Context context) {


### PR DESCRIPTION
Simply implement a `NULL` strategy as if Renjin had no support for locales.
 This seems to be the case when reading `setLocale`.