### PR TITLE
Upgrade to Apache Commons Compress 1.18

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.4.1</version>
+      <version>1.18</version>
     </dependency>
 
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -75,7 +75,11 @@
       <artifactId>commons-compress</artifactId>
       <version>1.18</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.tukaani</groupId>
+      <artifactId>xz</artifactId>
+      <version>1.8</version>
+    </dependency>
     <dependency>
       <groupId>org.renjin</groupId>
       <artifactId>renjin-asm</artifactId>


### PR DESCRIPTION
Resolves security vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2018-11771