### PR TITLE
Upgrade jackson-databind dependency of gcc-bridge-compiler

### DIFF
--- a/tools/gcc-bridge/compiler/pom.xml
+++ b/tools/gcc-bridge/compiler/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.2.0</version>
+      <version>2.8.11.1</version>
     </dependency>
     <dependency>
       <groupId>io.airlift</groupId>


### PR DESCRIPTION
This resolves several reported security vulnerabilities in earlier
versions of jackson databind:
https://nvd.nist.gov/vuln/detail/CVE-2017-17485
https://nvd.nist.gov/vuln/detail/CVE-2017-15095
https://nvd.nist.gov/vuln/detail/CVE-2018-7489
https://nvd.nist.gov/vuln/detail/CVE-2017-7525

N.B. These vulnerabilities did not affect Renjin or applications
developed with Renjin as we only ever use Jackson to parse JSON
from our own GCC-Bridge plugin during compile time. This has never
been used to parse trusted or untrusted JSON at runtime.