### PR TITLE
Fix pdf/png

### DIFF
--- a/packages/grDevices/src/main/R/JavaGD.R
+++ b/packages/grDevices/src/main/R/JavaGD.R
@@ -38,7 +38,7 @@ png <- function(filename = "Rplot%03d.png",
     if(!missing(antialias)) {
         new$antialias <- match.arg(antialias, aa.cairo)
     }
-    invisible(.Call(C_newJavaGD, filename, width, height, pointsize,
+    invisible(.Call(C_newJavaGD, filename, g$width, g$height, pointsize,
         "org.renjin.grDevices.FileDevice",
         list(filename = filename,
              format = "png",

--- a/packages/grDevices/src/main/R/postscript.R
+++ b/packages/grDevices/src/main/R/postscript.R
@@ -296,6 +296,8 @@ pdf <- function(file = if(onefile) "Rplots.pdf" else "Rplot%03d.pdf",
                 paper, encoding, bg, fg, pointsize, pagecentre, colormodel,
                 useDingbats, useKerning, fillOddEven, compress)
 {
+    if (is.null(file) ||  missing(file))
+        file <- if (!missing(onefile) && onefile) "Rplots.pdf" else "Rplot%03d.pdf"
     ## do initialization if needed
     initPSandPDFfonts()
 
@@ -366,9 +368,11 @@ pdf <- function(file = if(onefile) "Rplots.pdf" else "Rplot%03d.pdf",
         stop(gettextf("invalid 'file' argument '%s'", file), domain = NA)
 
     file <- sub("(.*)(\\.pdf{1})$", "\\1.png", file, ignore.case = TRUE)
-
-    png(filename = file, width = old$width, height = old$height,
-                       pointsize = old$pointsize, bg = old$bg)
+    png(filename = file, units = "in", res = 100,
+            width = if(!is.null(old$width)) old$width,
+            height = if(!is.null(old$height)) old$height,
+            pointsize = if(!is.null(old$pointsize)) old$pointsize,
+            bg = if(!is.null(old$bg)) old$bg)
     invisible()
 }
 

--- a/packages/grDevices/src/main/R/postscript.R
+++ b/packages/grDevices/src/main/R/postscript.R
@@ -364,12 +364,11 @@ pdf <- function(file = if(onefile) "Rplots.pdf" else "Rplot%03d.pdf",
     onefile <- old$onefile # needed to set 'file'
     if(!checkIntFormat(file))
         stop(gettextf("invalid 'file' argument '%s'", file), domain = NA)
-    .External(C_PDF,
-              file, old$paper, old$family, old$encoding, old$bg, old$fg,
-              old$width, old$height, old$pointsize, onefile, old$pagecentre,
-              old$title, old$fonts, version[1L], version[2L],
-              old$colormodel, old$useDingbats, old$useKerning,
-              old$fillOddEven, old$compress)
+
+    file <- sub("(.*)(\\.pdf{1})$", "\\1.png", file, ignore.case = TRUE)
+
+    png(filename = file, width = old$width, height = old$height,
+                       pointsize = old$pointsize, bg = old$bg)
     invisible()
 }
 


### PR DESCRIPTION
for now we pass calls to pdf to png()

`pdf` dimensions are always in inches. `png` has a `units` and `res` argument that is used to convert different dimension formats. 

`pdf` can take `NULL` as `file`, whereas `png` must have a `filename`.

`png` should pass dimensions that are converted by `.geometry()` to JavaGD driver

