### PR TITLE
Fix regression in S3 dispatch caused by 63bf94

### DIFF
--- a/core/src/main/java/org/renjin/primitives/Native.java
+++ b/core/src/main/java/org/renjin/primitives/Native.java
@@ -22,7 +22,10 @@ import org.renjin.base.Base;
 import org.renjin.eval.Context;
 import org.renjin.eval.EvalException;
 import org.renjin.eval.Profiler;
-import org.renjin.gcc.runtime.*;
+import org.renjin.gcc.runtime.BytePtr;
+import org.renjin.gcc.runtime.DoublePtr;
+import org.renjin.gcc.runtime.IntPtr;
+import org.renjin.gcc.runtime.PointerPtr;
 import org.renjin.invoke.annotations.*;
 import org.renjin.invoke.reflection.ClassBindingImpl;
 import org.renjin.invoke.reflection.FunctionBinding;
@@ -206,7 +209,7 @@ public class Native {
       }
       builder.add(callArguments.getName(i), sexpFromPointer(
           nativeArguments[i],
-          callArguments.get(i).getAttributes()));
+          callArguments.get(i)));
     }
     return builder.build();
   }
@@ -229,15 +232,15 @@ public class Native {
     return new PointerPtr(strings, 0);
   }
 
-  private static SEXP sexpFromPointer(Object ptr, AttributeMap attributes) {
+  private static SEXP sexpFromPointer(Object ptr, SEXP inputArgument) {
     // We are trusting the C code not to modify the arrays after the call
     // returns. 
     if(ptr instanceof DoublePtr) {
-      return DoubleArrayVector.unsafe(((DoublePtr) ptr).array, attributes);
+      return DoubleArrayVector.unsafe(((DoublePtr) ptr).array, inputArgument.getAttributes());
     } else if(ptr instanceof IntPtr) {
-      return new IntArrayVector(((IntPtr) ptr).array, attributes);
-    } else if(ptr instanceof ObjectPtr) {
-      return new NativeStringVector((ObjectPtr)ptr, attributes);
+      return new IntArrayVector(((IntPtr) ptr).array, inputArgument.getAttributes());
+    } else if(ptr instanceof PointerPtr) {
+      return new NativeStringVector((PointerPtr) ptr, inputArgument.getAttributes());
     } else {
       throw new UnsupportedOperationException(ptr.toString());
     }

--- a/core/src/main/java/org/renjin/primitives/NativeStringVector.java
+++ b/core/src/main/java/org/renjin/primitives/NativeStringVector.java
@@ -18,18 +18,20 @@
  */
 package org.renjin.primitives;
 
-import org.renjin.gcc.runtime.BytePtr;
 import org.renjin.gcc.runtime.ObjectPtr;
+import org.renjin.gcc.runtime.PointerPtr;
+import org.renjin.gcc.runtime.Ptr;
+import org.renjin.gcc.runtime.Stdlib;
 import org.renjin.sexp.AttributeMap;
 import org.renjin.sexp.StringVector;
 
 public class NativeStringVector extends StringVector {
   
-  private BytePtr[] array;
+  private Ptr[] array;
   private int offset;
   private int length;
 
-  public NativeStringVector(BytePtr[] array, int offset, int length, AttributeMap attributes) {
+  public NativeStringVector(Ptr[] array, int offset, int length, AttributeMap attributes) {
     super(attributes);
     this.array = array;
     this.offset = offset;
@@ -38,9 +40,16 @@ public class NativeStringVector extends StringVector {
 
   public NativeStringVector(ObjectPtr ptr, AttributeMap attributes) {
     super(attributes);
-    this.array = (BytePtr[])ptr.array;
+    this.array = (Ptr[])ptr.array;
     this.offset = ptr.offset;
     this.length = ptr.array.length;
+  }
+
+  public NativeStringVector(PointerPtr ptr, AttributeMap attributes) {
+    super(attributes);
+    this.array = (Ptr[]) ptr.getArray();
+    this.offset = 0;
+    this.length = this.array.length;
   }
 
   @Override
@@ -55,11 +64,11 @@ public class NativeStringVector extends StringVector {
 
   @Override
   public String getElementAsString(int index) {
-    BytePtr string = array[offset + index];
+    Ptr string = array[offset + index];
     if(string == null) {
       return null;
     } else {
-      return string.nullTerminatedString();
+      return Stdlib.nullTerminatedString(string);
     }
   }
 

--- a/core/src/main/java/org/renjin/primitives/S3.java
+++ b/core/src/main/java/org/renjin/primitives/S3.java
@@ -623,9 +623,14 @@ public class S3 {
         return next;
       }
 
-      // Look up the .default method in the calling environment
-      // and the original *definition environment*, *NOT* the methods table.
+      // Look up the .default method first in the definition environment
       GenericMethod function = findNext(definitionEnvironment, genericMethodName, "default");
+      if(function != null) {
+        return function;
+      }
+
+      // Otherwise see if *another* package has defined a default method
+      function = findNext(getMethodTable(), genericMethodName, "default");
       if(function != null) {
         return function;
       }

--- a/core/src/main/java/org/renjin/primitives/Vectors.java
+++ b/core/src/main/java/org/renjin/primitives/Vectors.java
@@ -284,7 +284,7 @@ public class Vectors {
     return asRaw(source.toVector());
   }
 
-  static Vector convertToAtomicVector(Vector.Builder builder, Vector source) {
+  public static Vector convertToAtomicVector(Vector.Builder builder, Vector source) {
     if(source instanceof ListVector) {
       for (int i = 0; i != source.length(); ++i) {
         SEXP value = ((ListVector) source).getElementAsSEXP(i);
@@ -434,7 +434,7 @@ public class Vectors {
    * @param x
    * @param mode
    */
-  private static void checkForListThatCannotBeCoercedToAtomicVector(Vector x, String mode) {
+  public static void checkForListThatCannotBeCoercedToAtomicVector(Vector x, String mode) {
     if(x instanceof ListVector) {
       ListVector list = (ListVector) x;
       for (int i = 0; i < list.length(); i++) {

--- a/tools/gnur-runtime/src/main/java/org/renjin/gnur/api/Rinternals.java
+++ b/tools/gnur-runtime/src/main/java/org/renjin/gnur/api/Rinternals.java
@@ -1175,9 +1175,9 @@ public final class Rinternals {
       case SexpType.LGLSXP:
         return Vectors.asLogical(((Vector) p0)).setAttributes(p0.getAttributes());
       case SexpType.INTSXP:
-        return new IntArrayVector((AtomicVector)p0);
+        return asIntArrayVector((Vector)p0);
       case SexpType.REALSXP:
-        return new DoubleArrayVector((AtomicVector) p0);
+        return asDoubleArrayVector((Vector) p0);
       case SexpType.CPLXSXP:
         return Vectors.asComplex((Vector)p0).setAttributes(p0.getAttributes());
       case SexpType.STRSXP:
@@ -1186,6 +1186,22 @@ public final class Rinternals {
         return toExpressionList(p0);
     }
     throw new UnimplementedGnuApiMethod("Rf_coerceVector: " + type);
+  }
+
+  private static SEXP asIntArrayVector(Vector vector) {
+    Vectors.checkForListThatCannotBeCoercedToAtomicVector(vector, "integer");
+
+    IntArrayVector.Builder builder = new IntArrayVector.Builder(0, vector.length());
+    Vector integerVector = Vectors.convertToAtomicVector(builder, vector);
+    return integerVector.setAttributes(vector.getAttributes());
+  }
+
+  private static SEXP asDoubleArrayVector(Vector vector) {
+    Vectors.checkForListThatCannotBeCoercedToAtomicVector(vector, "double");
+
+    DoubleArrayVector.Builder builder = new DoubleArrayVector.Builder(0, vector.length());
+    Vector integerVector = Vectors.convertToAtomicVector(builder, vector);
+    return integerVector.setAttributes(vector.getAttributes());
   }
 
   private static SEXP toExpressionList(SEXP sexp) {


### PR DESCRIPTION
When searching for default functions, we need to look in *both*
the definition environment, *and* the definition environment's method
table, in case *another* package has provided a default method.