### PR TITLE
Improve warning() implementation

### DIFF
--- a/core/src/main/R/base/conditions.R
+++ b/core/src/main/R/base/conditions.R
@@ -73,16 +73,13 @@ withCallingHandlers <- function(expr, ...) {
     expr
 }
 
-# Dummy implementation until we fix Renjin's condition/restart functionality
-suppressWarnings <- function(expr) expr
-
-#suppressWarnings <- function(expr) {
-#    ops <- options(warn = -1) ## FIXME: temporary hack until R_tryEval
-#    on.exit(options(ops))     ## calls are removed from methods code
-#    withCallingHandlers(expr,
-#                        warning=function(w)
-#                            invokeRestart("muffleWarning"))
-#}
+suppressWarnings <- function(expr) {
+    ops <- options(warn = -1) ## FIXME: temporary hack until R_tryEval
+    on.exit(options(ops))     ## calls are removed from methods code
+    withCallingHandlers(expr,
+                        warning=function(w)
+                            invokeRestart("muffleWarning"))
+}
 
 
 ##
@@ -302,10 +299,10 @@ withRestarts <- function(expr, ...) {
 ## Callbacks
 ##
 
-.signalSimpleWarning <- function(msg, call)
+.signalSimpleWarning <- function(msg, call, immediate = FALSE)
     withRestarts({
            .Internal(.signalCondition(simpleWarning(msg, call), msg, call))
-           .Internal(.dfltWarn(msg, call))
+           .Internal(.dfltWarn(msg, call, immediate))
         }, muffleWarning = function() NULL)
 
 .handleSimpleError <- function(h, msg, call)

--- a/core/src/main/R/base/stop.R
+++ b/core/src/main/R/base/stop.R
@@ -57,7 +57,7 @@ warning <- function(..., call. = TRUE, immediate. = FALSE, domain = NULL)
         call <- conditionCall(cond)
         withRestarts({
                 .Internal(.signalCondition(cond, message, call))
-                .Internal(.dfltWarn(message, call))
+                .Internal(.dfltWarn(message, call, FALSE))
             }, muffleWarning = function() NULL) #**** allow simpler form??
         invisible(message)
     } else

--- a/core/src/main/java/org/renjin/eval/ClosureDispatcher.java
+++ b/core/src/main/java/org/renjin/eval/ClosureDispatcher.java
@@ -76,7 +76,15 @@ public class ClosureDispatcher {
         }
       }
 
-      return closure.doApply(functionContext);
+      try {
+        return closure.doApply(functionContext);
+      } catch (EvalException e) {
+        // Associate this EvalException with this function call context if it's not already.
+        // N.B. initContext() also searches for condition handlers and may rethrow this
+        // EvalException as a ConditionException if found.
+        e.initContext(functionContext);
+        throw e;
+      }
 
     } catch(ReturnException e) {
       if (e.getEnvironment() != functionEnvironment) {
@@ -98,13 +106,6 @@ public class ClosureDispatcher {
       } else {
         throw e;
       }
-
-    } catch(EvalException e) {
-      // Associate this EvalException with this function call context if it's not already.
-      // N.B. initContext() also searches for condition handlers and may rethrow this
-      // EvalException as a ConditionException if found.
-      e.initContext(functionContext);
-      throw e;
 
     } finally {
       functionContext.exit();

--- a/core/src/main/java/org/renjin/eval/ClosureDispatcher.java
+++ b/core/src/main/java/org/renjin/eval/ClosureDispatcher.java
@@ -21,7 +21,6 @@ package org.renjin.eval;
 import org.renjin.primitives.special.ReturnException;
 import org.renjin.sexp.*;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
@@ -101,32 +100,15 @@ public class ClosureDispatcher {
       }
 
     } catch(EvalException e) {
-
+      // Associate this EvalException with this function call context if it's not already.
+      // N.B. initContext() also searches for condition handlers and may rethrow this
+      // EvalException as a ConditionException if found.
       e.initContext(functionContext);
-      SEXP handler = findHandler(functionContext, Arrays.asList("simpleError", "error", "condition"));
-      if(handler != null) {
-        // the R code in conditions.R expects this format (condition, message, handler).
-        // I think is the kind of thing that should be moved entirely into java to avoid
-        // these complicated relationships between R and Java/C code but i don't want
-        // to mess with the R code too much at this point.
+      throw e;
 
-        return new ListVector(e.getCondition(), Null.INSTANCE, handler);
-      } else {
-        throw e;
-      }
     } finally {
       functionContext.exit();
     }
-  }
-  
-  private static SEXP findHandler(Context context, Iterable<String> conditionClasses) {
-    for(String conditionClass : conditionClasses) {
-      ConditionHandler handler = context.getConditionHandler(conditionClass);
-      if(handler != null) {
-        return handler.getFunction();
-      }
-    }
-    return null;
   }
 
 

--- a/core/src/main/java/org/renjin/eval/Context.java
+++ b/core/src/main/java/org/renjin/eval/Context.java
@@ -559,7 +559,11 @@ public class Context {
 
 
   public void warn(String message) {
-    Warning.emitWarning(this, false, message);
+    Warning.warning(this, Null.INSTANCE, false, message);
+  }
+
+  public void warn(FunctionCall call, String message) {
+    Warning.warning(this, call, false, message);
   }
   
   /**

--- a/core/src/main/java/org/renjin/eval/EvalException.java
+++ b/core/src/main/java/org/renjin/eval/EvalException.java
@@ -19,6 +19,7 @@
 package org.renjin.eval;
 
 import org.renjin.eval.Context.Type;
+import org.renjin.primitives.Conditions;
 import org.renjin.sexp.ListVector;
 import org.renjin.sexp.SEXP;
 import org.renjin.sexp.StringArrayVector;
@@ -47,7 +48,7 @@ public class EvalException extends RuntimeException {
 
   public EvalException(Context context, String message, Object... args) {
     this(args.length == 0 ? message : String.format(message, args), (Throwable)null);
-    this.context = context;
+    initContext(context);
   }
 
 
@@ -62,6 +63,7 @@ public class EvalException extends RuntimeException {
   public void initContext(Context context) {
     if(this.context == null) {
       this.context = context;
+      Conditions.signalCondition(context, condition, null, null);
     }
   }
 

--- a/core/src/main/java/org/renjin/primitives/Evaluation.java
+++ b/core/src/main/java/org/renjin/primitives/Evaluation.java
@@ -531,7 +531,7 @@ public class Evaluation {
       }
       e = e.getParent();
     }
-    Warning.emitWarning(context, false,"object '" + name.getPrintName() + "' not found");
+    context.warn("object '" + name.getPrintName() + "' not found");
   }
 
 }

--- a/core/src/main/java/org/renjin/primitives/Primitives.java
+++ b/core/src/main/java/org/renjin/primitives/Primitives.java
@@ -190,7 +190,7 @@ public class Primitives {
     f(".resetCondHands", /*resetCondHands*/ null, 111);
     f(".signalCondition", Conditions.class, 11);
     f(".dfltStop", Conditions.class, 11);
-    f(".dfltWarn", /*dfltWarn*/ null, 11);
+    f(".dfltWarn", Warning.class, 11);
     f(".addRestart", Conditions.class, 11);
     f(".getRestart", Conditions.class, 11);
     f(".invokeRestart", Conditions.class, 11);

--- a/core/src/main/java/org/renjin/primitives/Warning.java
+++ b/core/src/main/java/org/renjin/primitives/Warning.java
@@ -19,12 +19,12 @@
 package org.renjin.primitives;
 
 import org.renjin.eval.Context;
+import org.renjin.eval.EvalException;
 import org.renjin.eval.Options;
 import org.renjin.invoke.annotations.Current;
 import org.renjin.invoke.annotations.Internal;
 import org.renjin.sexp.*;
 
-import java.io.IOException;
 import java.io.PrintWriter;
 
 
@@ -32,34 +32,67 @@ public class Warning {
 
   public static final Symbol LAST_WARNING = Symbol.get("last.warning");
 
-  public static void invokeWarning(@Current Context context, String message, Object... args) {
-    emitWarning(context, null, false, String.format(message, args));
-  }
-
-  public static void invokeWarning(@Current Context context, FunctionCall call, String message, Object... args) {
-    emitWarning(context, call, false, String.format(message, args));
-  }
-
+  /**
+   * Implementation of the .Internal(warning) R function.
+   *
+   * <p>Finds the call in which the warning was raised and then delegates to
+   * {@link #defaultWarning(Context, String, SEXP, boolean)}</p>
+   *
+   * @param context the current evaluation Context.
+   * @param call {@code true} if the call should become part of the warning message
+   * @param immediate {@code true} if the warning should be output, even if {@code getOption("warn") <= 0}
+   * @param message the warning message
+   */
   @Internal
-  public static void warning(@Current Context context, boolean call, boolean immediate, String message) throws IOException {
+  public static void warning(@Current Context context, boolean call, boolean immediate, String message) {
 
-    if(call || !immediate) {
-      FunctionCall currentCall = findCurrentCall(context, 1);
-
-      emitWarning(context, currentCall, immediate, message);
-
+    SEXP callSexp;
+    if(call) {
+      callSexp = findCurrentCall(context, 1);
     } else {
-      PrintWriter stderr = context.getSession().getEffectiveStdErr();
-      stderr.println("Warning message:");
-      stderr.println(message);
+      callSexp = Null.INSTANCE;
     }
+    warning(context, callSexp, immediate, message);
+  }
+
+  /**
+   * Initiates a warning in the given R context.
+   *
+   * <p>This method delegates to the R function {@code .signalSimpleWarning} which constructs and signals
+   * a simple warning condition.
+   *
+   * <p>If no restarts are invoked, {@code .signalSimpleWarning} proceeds to invoke
+   * {@link #defaultWarning(Context, String, SEXP, boolean)} via {@code .Internal(.dftlWarning())}</p>
+   *
+   *
+   * @param context the evaluation context
+   * @param call the {@link FunctionCall} in which the warning was raised, or {@code Null.INSTANCE}
+   * @param immediate true if the warning should be printed to the console immediately, or {@code false} if it
+   *                  should be collected until the end of the current evaluation loop. Overrides {@code option(warn)}
+   * @param message the warning message
+   */
+  public static void warning(Context context, SEXP call, boolean immediate, String message) {
+
+    SEXP quoteCall;
+    if(call == Null.INSTANCE) {
+      quoteCall = Null.INSTANCE;
+    } else {
+      quoteCall = FunctionCall.newCall(Symbol.get("quote"), call);
+    }
+
+    FunctionCall signalCall = FunctionCall.newCall(Symbol.get(".signalSimpleWarning"),
+        StringVector.valueOf(message),
+        quoteCall,
+        LogicalVector.valueOf(immediate));
+
+    context.evaluate(signalCall, context.getGlobalEnvironment());
   }
 
   /**
    * Finds the FunctionCall from which the warning was emitted, or null if 
    * warning was invoked from a top level context.
    */
-  private static FunctionCall findCurrentCall(Context context, int toSkip) {
+  private static SEXP findCurrentCall(Context context, int toSkip) {
     while(!context.isTopLevel()) {
       if(context.getCall() != null) {
         if(toSkip == 0) {
@@ -70,55 +103,63 @@ public class Warning {
       context = context.getParent();
     }
     // we were at the top level
-    return null;
-  }
-
-  public static void emitWarning(Context context, boolean immediate, String message) {
-    emitWarning(context, findCurrentCall(context, 0), immediate, message);
-  }
-
-  public static void emitWarning(Context context, FunctionCall call,  boolean immediate, String message)  {
-
-    // Create the condition object
-    ListVector.NamedBuilder condition = new ListVector.NamedBuilder();
-    condition.setAttribute(Symbols.CLASS, new StringArrayVector("simpleWarning", "warning", "condition"));
-    condition.add("message", message);
-    if(call != null) {
-      condition.add("call", call);
-    }
-
-    // Try signaling the condition
-    Conditions.signalCondition(context, condition.build(), message, call);
-
-    // If ConditionException is not thrown, then proceed with default behavior
-    uncaughtWarning(context, call, immediate, message);
+    return Null.INSTANCE;
   }
 
   /**
-   * Handle a warning that is not caught by any condition handlers installed by the user
+   * Implements the "default" behavior of a warning.
+   *
+   * <p>This method is invoked by the R function {@code .signalSimpleWarning}, or by the R base function
+   * {@code warning} if a condition object is provided.
    */
-  private static void uncaughtWarning(Context context, FunctionCall call, boolean immediate, String message) {
+  @Internal(".dfltWarn")
+  public static void defaultWarning(@Current Context context, String message, SEXP call, boolean immediate) {
+
+    // Step 0: TODO
+    // Ignore warnings raised during the handling of other warnings.
+
+
+    // Step 1: check for presence of option(warning.expression)
+    // If present, delegate and exit.
+
+    SEXP warningExpression = context.getSession().getSingleton(Options.class).get("warning.expression");
+    if(warningExpression != Null.INSTANCE) {
+      context.evaluate(warningExpression, context.getGlobalEnvironment());
+      return;
+    }
+
+    // Step 2: Consult the global warning level
+
     int warnMode = context.getSession().getSingleton(Options.class).getInt("warn", 0);
+    if(IntVector.isNA(warnMode)) {
+      warnMode = 0;
+    }
+
+    // Step 2a: If options('warn') >= 2, convert the warning to an error
+    if(warnMode >= 2) {
+      throw new EvalException(String.format("(converted from warning) %s", message));
+    }
+
+    // Step 2b: If options('warn') == 1, or immediate flag is set, print immediately
+
     if(warnMode == 1 || (warnMode <= 0 && immediate)) {
       PrintWriter stderr = context.getSession().getEffectiveStdErr();
       stderr.println("Warning in " + call.toString() + " :");
       stderr.println("  " + message);
-    } else if(warnMode == 0) {
-      // store warnings until end of evaluation
+      return;
 
-      ListVector.NamedBuilder lastWarning = new ListVector.NamedBuilder();
-
-      Environment baseEnv = context.getBaseEnvironment();
-      if(baseEnv.hasVariable(LAST_WARNING)) {
-        lastWarning.addAll((ListVector)baseEnv.getVariable(context, LAST_WARNING).force(context));
-      }
-      if(call != null) {
-        lastWarning.add(message, call);
-      } else {
-        lastWarning.add(message, Null.INSTANCE);
-      }
-      baseEnv.setVariable(context, LAST_WARNING, lastWarning.build());
     }
+
+    // Step 2c: Otherwise, collect the warning for printing at the end of the current statement
+
+    ListVector.NamedBuilder lastWarning = new ListVector.NamedBuilder();
+
+    Environment baseEnv = context.getBaseEnvironment();
+    if(baseEnv.hasVariable(LAST_WARNING)) {
+      lastWarning.addAll((ListVector)baseEnv.getVariable(context, LAST_WARNING).force(context));
+    }
+    lastWarning.add(message, call);
+    baseEnv.setVariable(context, LAST_WARNING, lastWarning.build());
   }
 
   @Internal

--- a/core/src/main/java/org/renjin/primitives/files/Files.java
+++ b/core/src/main/java/org/renjin/primitives/files/Files.java
@@ -22,7 +22,6 @@ import org.apache.commons.vfs2.*;
 import org.renjin.eval.Context;
 import org.renjin.eval.EvalException;
 import org.renjin.invoke.annotations.*;
-import org.renjin.primitives.Warning;
 import org.renjin.primitives.text.regex.ExtendedRE;
 import org.renjin.primitives.text.regex.REFactory;
 import org.renjin.primitives.text.regex.RESyntaxException;
@@ -882,7 +881,7 @@ public class Files {
 
     } catch (Exception e) {
       if(showWarnings) {
-        Warning.invokeWarning(context, "cannot create file '%s', reason '%s'", fileName, e.getMessage());
+        context.warn(String.format("cannot create file '%s', reason '%s'", fileName, e.getMessage()));
       }
       return false;
     }

--- a/core/src/main/java/org/renjin/primitives/matrix/Matrices.java
+++ b/core/src/main/java/org/renjin/primitives/matrix/Matrices.java
@@ -25,7 +25,6 @@ import org.renjin.invoke.annotations.Current;
 import org.renjin.invoke.annotations.Generic;
 import org.renjin.invoke.annotations.Internal;
 import org.renjin.primitives.Indexes;
-import org.renjin.primitives.Warning;
 import org.renjin.primitives.sequence.RepDoubleVector;
 import org.renjin.primitives.sequence.RepLogicalVector;
 import org.renjin.primitives.vector.ComputingIntVector;
@@ -410,20 +409,19 @@ public class Matrices {
         if (((dataLength > nrow) && (dataLength / nrow) * nrow != dataLength) ||
                 ((dataLength < nrow) && (nrow / dataLength) * dataLength != nrow)) {
 
-          Warning.invokeWarning(context,
+          context.warn(String.format(
                   "data length [%d] is not a sub-multiple or multiple of the number of rows [%d]",
-                  dataLength, nrow);
+                  dataLength, nrow));
 
         } else if (((dataLength > ncol) && (dataLength / ncol) * ncol != dataLength) ||
                 ((dataLength < ncol) && (ncol / dataLength) * dataLength != ncol)) {
 
-          Warning.invokeWarning(context,
+          context.warn(String.format(
                   "data length [%d] is not a sub-multiple or multiple of the number of columns [%d]",
-                  dataLength, ncol);
+                  dataLength, ncol));
         }
       }  else if ((dataLength > 1) && (nrow * ncol == 0)){
-        Warning.invokeWarning(context,
-                "data length exceeds size of matrix");
+        context.warn("data length exceeds size of matrix");
       }
     }
 

--- a/core/src/main/java/org/renjin/primitives/packaging/BasePackage.java
+++ b/core/src/main/java/org/renjin/primitives/packaging/BasePackage.java
@@ -18,6 +18,9 @@
  */
 package org.renjin.primitives.packaging;
 
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemManager;
 import org.renjin.eval.Context;
 import org.renjin.sexp.NamedValue;
 import org.renjin.util.NamedByteSource;
@@ -43,5 +46,10 @@ public class BasePackage extends Package {
   @Override
   public Class loadClass(String name) {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public FileObject resolvePackageRoot(FileSystemManager fileSystemManager) throws FileSystemException {
+    return fileSystemManager.resolveFile("res:org/renjin/base/DESCRIPTION").getParent();
   }
 }

--- a/core/src/main/java/org/renjin/primitives/sequence/Sequences.java
+++ b/core/src/main/java/org/renjin/primitives/sequence/Sequences.java
@@ -23,7 +23,6 @@ import org.renjin.eval.EvalException;
 import org.renjin.invoke.annotations.Builtin;
 import org.renjin.invoke.annotations.Current;
 import org.renjin.invoke.annotations.Internal;
-import org.renjin.primitives.Warning;
 import org.renjin.repackaged.guava.annotations.VisibleForTesting;
 import org.renjin.sexp.*;
 
@@ -71,7 +70,7 @@ public class Sequences {
     if(exp.length() == 0) {
       throw new EvalException("argument of length 0");
     } else if(exp.length() > 1) {
-      Warning.invokeWarning(context, "numerical expression has %d elements: only the first used", exp.length());
+      context.warn(String.format("numerical expression has %d elements: only the first used", exp.length()));
     }
   }
 

--- a/core/src/main/java/org/renjin/sexp/SpecialFunction.java
+++ b/core/src/main/java/org/renjin/sexp/SpecialFunction.java
@@ -20,7 +20,6 @@ package org.renjin.sexp;
 
 import org.renjin.eval.Context;
 import org.renjin.eval.EvalException;
-import org.renjin.primitives.Warning;
 
 
 public abstract class SpecialFunction extends PrimitiveFunction {
@@ -54,7 +53,7 @@ public abstract class SpecialFunction extends PrimitiveFunction {
       throw new EvalException("argument is of length zero");
     }
     if (s.length() > 1) {
-      Warning.invokeWarning(context, call, "the condition has length > 1 and only the first element will be used");
+      context.warn(call, "the condition has length > 1 and only the first element will be used");
     }
 
     s = context.materialize(s);

--- a/core/src/main/resources/org/renjin/base/DESCRIPTION
+++ b/core/src/main/resources/org/renjin/base/DESCRIPTION
@@ -1,0 +1,8 @@
+Package: base
+Version: 3.4.0
+Priority: base
+Title: The R Base Package
+Author: R Core Team and contributors worldwide
+Maintainer: R Core Team <R-core@r-project.org>
+Description: Base R functions.
+License: Part of R 3.4.0

--- a/packages/utils/src/main/R/indices.R
+++ b/packages/utils/src/main/R/indices.R
@@ -29,9 +29,7 @@ packageDescription <-
     ## the loaded packages/namespaces are searched before the libraries.
     pkgpath <-
 	if(is.null(lib.loc)) {
-	    if(pkg == "base")
-		file.path(.Library, "base")
-	    else if(isNamespaceLoaded(pkg))
+	    if(isNamespaceLoaded(pkg))
 		getNamespaceInfo(pkg, "path")
 	    else if((envname <- paste0("package:", pkg)) %in% search()) {
 		attr(as.environment(envname), "path")

--- a/tests/src/test/R/test.sessionInfo.R
+++ b/tests/src/test/R/test.sessionInfo.R
@@ -1,0 +1,24 @@
+#
+# Renjin : JVM-based interpreter for the R language for the statistical analysis
+# Copyright © 2010-2018 BeDataDriven Groep B.V. and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, a copy is available at
+# https://www.gnu.org/licenses/gpl-2.0.txt
+#
+
+library(utils)
+
+si <- sessionInfo()
+
+print(si)

--- a/tests/src/test/R/test.suppressWarnings.R
+++ b/tests/src/test/R/test.suppressWarnings.R
@@ -1,0 +1,38 @@
+
+#
+# Renjin : JVM-based interpreter for the R language for the statistical analysis
+# Copyright © 2010-2018 BeDataDriven Groep B.V. and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, a copy is available at
+# https://www.gnu.org/licenses/gpl-2.0.txt
+#
+
+library(hamcrest)
+
+# Make sure warnings actually work if not suppressed
+
+warningCount <- 0
+
+options(warning.expression = quote({ warningCount <<- warningCount + 1; cat(sprintf("warnings = %d\n", warningCount)) }))
+
+warning("foo")
+assertThat(warningCount, identicalTo(1))
+
+suppressWarnings(warning("bar", .call = FALSE))
+
+assertThat(warningCount, identicalTo(1))
+
+
+
+

--- a/tests/src/test/R/test.try.R
+++ b/tests/src/test/R/test.try.R
@@ -1,0 +1,42 @@
+#
+# Renjin : JVM-based interpreter for the R language for the statistical analysis
+# Copyright © 2010-2018 BeDataDriven Groep B.V. and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, a copy is available at
+# https://www.gnu.org/licenses/gpl-2.0.txt
+#
+
+library(hamcrest)
+
+test.error <- function() {
+
+    e <- try(stop('foo'))
+
+    assertThat(class(e), identicalTo("try-error"))
+
+    condition <- attr(e, 'condition')
+
+    assertThat(condition$message, identicalTo("foo"))
+}
+
+test.silent <- function() {
+
+    e <- try(stop('foo'), silent = TRUE)
+
+    assertThat(class(e), identicalTo("try-error"))
+
+    condition <- attr(e, 'condition')
+
+    assertThat(condition$message, identicalTo("foo"))
+}

--- a/tests/src/test/R/test.warning1.R
+++ b/tests/src/test/R/test.warning1.R
@@ -1,0 +1,42 @@
+#
+# Renjin : JVM-based interpreter for the R language for the statistical analysis
+# Copyright © 2010-2018 BeDataDriven Groep B.V. and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, a copy is available at
+# https://www.gnu.org/licenses/gpl-2.0.txt
+#
+
+library(hamcrest)
+
+
+# During the first phase, the warning is signaled as a condition
+# This should happen whether immediate. = TRUE or if options("warn") is disabled
+
+options(warn = -1)
+
+signaledCondition <- NULL
+continues <- FALSE
+
+withCallingHandlers({
+    warning("foo", immediate. = TRUE, call. = FALSE);
+    continues <<- TRUE
+
+}, warning=function(w) signaledCondition <<- w)
+
+
+assertThat(signaledCondition, identicalTo(
+        structure(list(message = "foo", call = NULL), class = c("simpleWarning", "warning", "condition"))))
+
+assertThat(continues, identicalTo(TRUE))
+

--- a/tests/src/test/R/test.warning2.R
+++ b/tests/src/test/R/test.warning2.R
@@ -1,0 +1,32 @@
+#
+# Renjin : JVM-based interpreter for the R language for the statistical analysis
+# Copyright © 2010-2018 BeDataDriven Groep B.V. and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, a copy is available at
+# https://www.gnu.org/licenses/gpl-2.0.txt
+#
+
+library(hamcrest)
+
+
+# During the process of raising the warning condition, a "muffleWarning" restart
+# should be available.
+
+withCallingHandlers({
+    warning("foo", immediate. = TRUE, call. = FALSE);
+
+}, warning=function(w) restart <<- findRestart("muffleWarning"))
+
+
+assertThat(restart$name, identicalTo("muffleWarning"))

--- a/tests/src/test/R/test.withCallingHandlers.R
+++ b/tests/src/test/R/test.withCallingHandlers.R
@@ -78,6 +78,18 @@ test.rethrow <- function() {
     # skip silently terminate code
     skip =  function(e) {}
     )
+}
 
+test.errors <- function() {
 
+    errorHandlerCalled <- FALSE
+    flowResumed <- FALSE
+
+    ev <- try(withCallingHandlers({
+            stop('foo')
+            flowResumed <<- TRUE
+        }, error = function(e) { errorHandlerCalled <<- TRUE }), silent=TRUE)
+
+    assertThat(class(ev), identicalTo("try-error"))
+    assertTrue(errorHandlerCalled)
 }

--- a/tools/gnur-runtime/src/main/java/org/renjin/gnur/api/Error.java
+++ b/tools/gnur-runtime/src/main/java/org/renjin/gnur/api/Error.java
@@ -22,6 +22,7 @@ package org.renjin.gnur.api;
 import org.renjin.eval.EvalException;
 import org.renjin.gcc.runtime.BytePtr;
 import org.renjin.gcc.runtime.Stdlib;
+import org.renjin.primitives.Native;
 
 import static org.renjin.gnur.api.Utils.R_CheckUserInterrupt;
 
@@ -40,7 +41,7 @@ public final class Error {
   }
 
   public static void Rf_warning(BytePtr text, Object... formatArgs) {
-    Stdlib.printf(text, formatArgs);
+    Native.currentContext().warn(Stdlib.format(text, formatArgs));
   }
 
   public static void Rf_error(BytePtr text, Object... formatArguments) {
@@ -58,15 +59,12 @@ public final class Error {
     throw new UnimplementedGnuApiMethod("WrongArgCount");
   }
 
-  // void Rf_warning (const char *,...)
-
   public static void R_ShowMessage(BytePtr s) {
     throw new UnimplementedGnuApiMethod("R_ShowMessage");
   }
 
   public static void rwarn_(BytePtr message, int messageLen) {
-    // TODO: hook into warnings
-    System.err.println(message.toString(messageLen));
+    Native.currentContext().warn(message.toString(messageLen));
   }
 
   public static void rexit_(BytePtr message, int messageLen) {

--- a/tools/gnur-runtime/src/main/java/org/renjin/gnur/api/Rinternals.java
+++ b/tools/gnur-runtime/src/main/java/org/renjin/gnur/api/Rinternals.java
@@ -2520,16 +2520,13 @@ public final class Rinternals {
     throw new EvalException(errorMessage);
   }
 
-  public static void Rf_warningcall (SEXP callSexp, Ptr format, Object... args) {
-    String message = Stdlib.format(format, new FormatArrayInput(args));
-    FunctionCall call = null;
-    if(callSexp instanceof FunctionCall) {
-      call = (FunctionCall) callSexp;
-    }
-    Warning.emitWarning(Native.currentContext(), call, false, message);
+  public static void Rf_warningcall (SEXP call, Ptr format, Object... args) {
+    Warning.warning(Native.currentContext(), call, false, Stdlib.format(format, new FormatArrayInput(args)));
   }
 
-  // void Rf_warningcall_immediate (SEXP, const char *,...)
+  public static void Rf_warningcall_immediate(SEXP call, Ptr format, Object... args) {
+    Warning.warning(Native.currentContext(), call, true, Stdlib.format(format, new FormatArrayInput(args)));
+  }
 
   public static void R_XDREncodeDouble(double d, Object buf) {
     throw new UnimplementedGnuApiMethod("R_XDREncodeDouble");


### PR DESCRIPTION
* Ensure that a warning is always signaled, even if immediate = TRUE
* Ensure muffleWarning restart is always defined
* Honor options("warning.expression")
* Ensure that all internal warnings follow same execution path