### PR TITLE
Add extensions demo

### DIFF
--- a/demos/extensions/LICENSE
+++ b/demos/extensions/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Per Nyfelt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/demos/extensions/NAMESPACE
+++ b/demos/extensions/NAMESPACE
@@ -1,0 +1,3 @@
+export(meantrim)
+export(extractDigits)
+export(makeNumber)

--- a/demos/extensions/pom.xml
+++ b/demos/extensions/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>demos</artifactId>
+    <groupId>org.renjin</groupId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.mycompany</groupId>
+  <artifactId>extensionsdemo</artifactId>
+  <packaging>jar</packaging>
+
+  <!-- general information about your package -->
+  <name>Renjin demos - extensions</name>
+  <description>Two extensions as described in the docs on creating extensions</description>
+  <url>http://docs.renjin.org/en/latest/writing-renjin-extensions.html</url>
+  <licenses>
+    <!-- add one or more licenses under which the package is released -->
+    <license>
+      <name>MIT License</name>
+      <url>https://opensource.org/licenses/MIT</url>
+    </license>
+  </licenses>
+
+  <properties>
+    <renjin.version>0.9.2716</renjin.version>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  </properties>
+
+  <dependencies>
+    <!-- the script engine is convenient even if you do not use it explicitly -->
+    <dependency>
+      <groupId>org.renjin</groupId>
+      <artifactId>renjin-script-engine</artifactId>
+      <version>${renjin.version}</version>
+    </dependency>
+    <!-- the hamcrest package is only required if you use it for unit tests -->
+    <dependency>
+      <groupId>org.renjin</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>${renjin.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <repositories>
+    <repository>
+      <id>bedatadriven</id>
+      <name>bedatadriven public repo</name>
+      <url>https://nexus.bedatadriven.com/content/groups/public/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>bedatadriven</id>
+      <name>bedatadriven public repo</name>
+      <url>https://nexus.bedatadriven.com/content/groups/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.renjin</groupId>
+        <artifactId>renjin-maven-plugin</artifactId>
+        <version>${renjin.version}</version>
+        <executions>
+          <execution>
+            <id>build</id>
+            <goals>
+              <goal>namespace-compile</goal>
+            </goals>
+            <phase>process-classes</phase>
+          </execution>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <phase>test</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/demos/extensions/src/main/R/extractDigits.R
+++ b/demos/extensions/src/main/R/extractDigits.R
@@ -1,0 +1,5 @@
+extractDigits <- function(x) {
+    import(transformers.StringTransformer)
+    sapply(x, function(txt) StringTransformer$toNumber(txt = txt), USE.NAMES = FALSE)
+}
+makeNumber <- function(x) as.numeric(extractDigits(x))

--- a/demos/extensions/src/main/R/meantrim.R
+++ b/demos/extensions/src/main/R/meantrim.R
@@ -1,0 +1,5 @@
+meantrim <- function(x) {
+    x <- x[x != max(x)]
+    x <- x[x != min(x)]
+    return(mean(x))
+}

--- a/demos/extensions/src/main/java/transformers/StringTransformer.java
+++ b/demos/extensions/src/main/java/transformers/StringTransformer.java
@@ -1,0 +1,12 @@
+package transformers;
+
+public class StringTransformer {
+
+  public static String toNumber(String txt) {
+    StringBuilder result = new StringBuilder();
+    txt.chars().mapToObj(i -> (char) i)
+        .filter(c -> Character.isDigit(c))
+        .forEach(c -> result.append(c));
+    return result.toString();
+  }
+}

--- a/demos/extensions/src/test/R/test.extractDigits.R
+++ b/demos/extensions/src/test/R/test.extractDigits.R
@@ -1,0 +1,16 @@
+library("com.mycompany:extensionsdemo")
+library("hamcrest")
+
+test.extractDigits <- function() {
+    assertThat(extractDigits(c("5", "6Y8", "He", "02")), identicalTo(c("5", "68", "", "02")))
+    assertThat(extractDigits("56Y8He02"), identicalTo("56802"))
+}
+
+test.makeNumber <- function() {
+    expected <- c(5, 68, NA, 2)
+    assertThat(makeNumber(c("5", "6Y8", "He", "02")), identicalTo(expected))
+    assertThat(makeNumber("234-123-789 12"), identicalTo(23412378912))
+}
+
+
+

--- a/demos/extensions/src/test/R/test.meantrim.R
+++ b/demos/extensions/src/test/R/test.meantrim.R
@@ -1,0 +1,4 @@
+library("com.mycompany:extensionsdemo")
+library("hamcrest")
+
+assertThat(meantrim(1:10), identicalTo(5.5))

--- a/demos/pom.xml
+++ b/demos/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.renjin</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>demos</artifactId>
+  <packaging>pom</packaging>
+  <name>Demos and samplecode</name>
+
+  <modules>
+    <module>extensions</module>
+  </modules>
+
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <module>dist/deb</module>
     <module>dist/gnur</module>
     <module>math</module>
+    <module>demos</module>
   </modules>
 
   <properties>

--- a/tools/maven-plugin/src/main/java/org/renjin/maven/test/ForkedTestController.java
+++ b/tools/maven-plugin/src/main/java/org/renjin/maven/test/ForkedTestController.java
@@ -188,7 +188,7 @@ public class ForkedTestController {
 
     } catch (Exception e) {
       log.debug("ForkedTestController received exception while waiting for results.", e);
-      reporter.testCaseFailed();
+      reporter.testCaseFailed(e.getMessage());
       return false;
     }
   }

--- a/tools/maven-plugin/src/main/java/org/renjin/maven/test/TestReporter.java
+++ b/tools/maven-plugin/src/main/java/org/renjin/maven/test/TestReporter.java
@@ -122,7 +122,7 @@ public class TestReporter {
   }
   
   public void testCaseFailed() {
-    testCaseFailed(null);
+    testCaseFailed("");
   }
 
   public void testCaseFailed(String message)  {


### PR DESCRIPTION
I propose a module under parent for demos and sample code. I have added the Renjin extensions demo that have been discussed recently on the mail list (based on info from Parham Solaimani). For these demos I think MIT license is more appropriate than GPL to encourage any usage in any context but no problem to change to (or dual license) as GPL if needed.

One thing i am not sure about is the version number reference to renjin in the pom. It would be nice if RELEASE worked but it does not. Maybe there is some system property or similar that can be used instead?