### PR TITLE
Fixes #434: Ensure that graphics routines can be called from any thread

### DIFF
--- a/script-engine/src/test/java/org/renjin/script/ThreadTest.java
+++ b/script-engine/src/test/java/org/renjin/script/ThreadTest.java
@@ -1,0 +1,56 @@
+/*
+ * Renjin : JVM-based interpreter for the R language for the statistical analysis
+ * Copyright © 2010-2018 BeDataDriven Groep B.V. and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, a copy is available at
+ * https://www.gnu.org/licenses/gpl-2.0.txt
+ */
+package org.renjin.script;
+
+import org.junit.Test;
+
+import javax.script.ScriptException;
+import java.io.IOException;
+
+public class ThreadTest {
+
+  @Test
+  public void testGraphicsInNewThread() throws IOException, ScriptException, InterruptedException {
+
+    // Start a new session in the current thread
+    RenjinScriptEngine engine = new RenjinScriptEngineFactory().getScriptEngine();
+    engine.eval("f <- tempfile()");
+
+
+    // Define a task that can be run in a new thread
+    Runnable plotTask = () -> {
+      try {
+        engine.eval("png(f)");
+        engine.eval("plot(1:12)");
+        engine.eval("dev.off()");
+      } catch (ScriptException e) {
+        throw new RuntimeException(e);
+      }
+    };
+
+    // Start a new thread, run the task, and wait for it to complete
+    Thread thread = new Thread(plotTask);
+    thread.start();
+    thread.join();
+
+    // Verify that file is written
+    engine.eval("stopifnot(file.exists(f))");
+
+  }
+}

--- a/tools/gnur-compiler/src/main/java/org/renjin/gnur/ContextClassWriter.java
+++ b/tools/gnur-compiler/src/main/java/org/renjin/gnur/ContextClassWriter.java
@@ -43,12 +43,9 @@ import static org.renjin.repackaged.asm.Opcodes.*;
 
 public class ContextClassWriter {
 
-  public static final String THREAD_LOCAL_FIELD_NAME = "CURRENT";
-  public static final String THREAD_LOCAL_DESCRIPTOR = Type.getDescriptor(ThreadLocal.class);
-  public static final String ENTER_METHOD_DESCRIPTOR = Type.getMethodDescriptor(Type.getType(Object.class));
-
   private final Type contextClass;
-  private ClassWriter cv;
+  private final String currentMethodDescriptor;
+  private final ClassWriter cv;
 
   public ContextClassWriter(Type contextClass) {
     this.contextClass = contextClass;
@@ -56,82 +53,37 @@ public class ContextClassWriter {
     cv.visit(V1_8, ACC_PUBLIC + ACC_SUPER, contextClass.getInternalName(), null,
         Type.getInternalName(Object.class), new String[0]);
 
-    threadLocalHolder();
-    staticInitializer();
-    enterMethod();
+    currentMethodDescriptor = Type.getMethodDescriptor(contextClass);
+
+    writeCurrentMethod();
   }
 
-  /**
-   * Declares a field of type {@code ThreadLocal<PackageContext>} that will hold the instance of the PackageContext
-   * associated with the current thread. This is set by the {@code enter()} method called by the trampoline class.
-   */
-  private void threadLocalHolder() {
-    cv.visitField(ACC_PUBLIC | ACC_STATIC, THREAD_LOCAL_FIELD_NAME, THREAD_LOCAL_DESCRIPTOR, null, null);
-  }
 
   /**
-   * Writes a static initializer that initialize our ThreadLocal static variable with a new instance.
-   */
-  private void staticInitializer() {
-    MethodVisitor mv = cv.visitMethod(ACC_PUBLIC | ACC_STATIC, "<clinit>", "()V", null, null);
-    mv.visitCode();
-    mv.visitTypeInsn(Opcodes.NEW, Type.getInternalName(ThreadLocal.class));
-    mv.visitInsn(Opcodes.DUP);
-    mv.visitMethodInsn(Opcodes.INVOKESPECIAL, Type.getInternalName(ThreadLocal.class), "<init>", "()V", false);
-    mv.visitFieldInsn(Opcodes.PUTSTATIC, contextClass.getInternalName(), THREAD_LOCAL_FIELD_NAME, THREAD_LOCAL_DESCRIPTOR);
-    mv.visitInsn(Opcodes.RETURN);
-    mv.visitMaxs(1,1);
-    mv.visitEnd();
-  }
-
-  /**
-   * Writes a static enter() method that initializes the PackageState from this thread by calling
+   * Writes a static current() method that retrieves the PackageState from this thread by calling
    * {@code Native.currentContext().getSingleton(org.renjin.cran.mypackage.Context.class)}
    */
-  private void enterMethod() {
-    MethodVisitor mv = cv.visitMethod(ACC_PUBLIC | ACC_STATIC, "enter", ENTER_METHOD_DESCRIPTOR, null, null);
+  private void writeCurrentMethod() {
+    MethodVisitor mv = cv.visitMethod(ACC_PUBLIC | ACC_STATIC, "current", currentMethodDescriptor,
+        null, null);
     mv.visitCode();
-
-    mv.visitFieldInsn(Opcodes.GETSTATIC, contextClass.getInternalName(), THREAD_LOCAL_FIELD_NAME, THREAD_LOCAL_DESCRIPTOR);
-
-    // Stack: ThreadLocal
-
-    mv.visitInsn(Opcodes.DUP);
-
-    // Stack: ThreadLocal, ThreadLocal
-
-    // Retrieve the current value and store it a local variable
-
-    mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(ThreadLocal.class), "get",
-        Type.getMethodDescriptor(Type.getType(Object.class)), false);
-
-    mv.visitVarInsn(Opcodes.ASTORE, 0);
-
-    // Stack: ThreadLocal
 
     mv.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(Native.class), "currentContext",
         Type.getMethodDescriptor(Type.getType(Context.class)), false);
 
-    // Stack: ThreadLocal, org.renjin.eval.Context
+    // Stack: org.renjin.eval.Context
 
     mv.visitLdcInsn(contextClass);
 
-    // Stack: ThreadLocal, org.renjin.eval.Context, org.renjin.cran.mypackage.Context
+    // Stack: org.renjin.eval.Context, org.renjin.cran.mypackage.Context.class
 
     // Call context.getSingleton(org.renjin.cran.mypackage.Context.class)
 
     mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(Context.class), "getSingleton",
         Type.getMethodDescriptor(Type.getType(Object.class), Type.getType(Class.class)), false);
 
-    // Stack: ThreadLocal, org.renjin.cran.mypackage.Context
+    mv.visitTypeInsn(CHECKCAST, contextClass.getInternalName());
 
-    // Update the ThreadLocal field (already on the stack)
-    mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(ThreadLocal.class), "set",
-        Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(Object.class)), false);
-
-    // Now return the previous value
-
-    mv.visitVarInsn(Opcodes.ALOAD, 0);
     mv.visitInsn(Opcodes.ARETURN);
     mv.visitMaxs(1,1);
     mv.visitEnd();
@@ -190,11 +142,7 @@ public class ContextClassWriter {
 
   private void writeLoadCurrentContext(MethodVisitor mv) {
     // Retrieve the current ThreadLocal instance
-    mv.visitFieldInsn(Opcodes.GETSTATIC, contextClass.getInternalName(), THREAD_LOCAL_FIELD_NAME, Type.getDescriptor(ThreadLocal.class));
-    mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(ThreadLocal.class), "get", Type.getMethodDescriptor(Type.getType(Object.class)), false);
-
-    // Cast to our context class
-    mv.visitTypeInsn(Opcodes.CHECKCAST, contextClass.getInternalName());
+    mv.visitMethodInsn(INVOKESTATIC, contextClass.getInternalName(), "current", currentMethodDescriptor, false);
   }
 
 
@@ -231,7 +179,6 @@ public class ContextClassWriter {
     for (GimpleVarDecl globalVar : globalVars) {
       writeGlobalVarInit(generationContext, methodGenerator, globalVar);
     }
-
 
     mv.visitInsn(RETURN);
     mv.visitMaxs(1, 1);

--- a/tools/gnur-compiler/src/main/java/org/renjin/gnur/GlobalVarPlugin.java
+++ b/tools/gnur-compiler/src/main/java/org/renjin/gnur/GlobalVarPlugin.java
@@ -23,7 +23,6 @@ import org.renjin.gcc.codegen.CodeGenerationContext;
 import org.renjin.gcc.codegen.FunctionGenerator;
 import org.renjin.gcc.codegen.GlobalVarTransformer;
 import org.renjin.repackaged.asm.MethodVisitor;
-import org.renjin.repackaged.asm.Opcodes;
 import org.renjin.repackaged.asm.Type;
 
 import javax.annotation.Nonnull;
@@ -72,9 +71,6 @@ public class GlobalVarPlugin extends GimpleCompilerPlugin {
 
   @Override
   public void writeTrampolinePrelude(MethodVisitor mv, FunctionGenerator functionGenerator) {
-    mv.visitMethodInsn(Opcodes.INVOKESTATIC, contextClass.getInternalName(), "enter",
-        ContextClassWriter.ENTER_METHOD_DESCRIPTOR, false);
-    mv.visitInsn(Opcodes.POP);
   }
 
   @Override


### PR DESCRIPTION
This removes a problematic thread-local cache of global variables
for the graphics and grDevices packages.

The result is that cost of reading/writing global variables from
compiled C code may be slightly higher, but it will be correct.

The alternatives would be to either initialize the thread state for
ever package on every native call, or to require the user of Renjin
to manually manage ScriptEngine-to-thread mappings.

If the overhead proves to be too high, there are better optimizations
that we can pursue, such as batch retrievals of package state within
functions, etc, that won't sacrifice correctness.