### PR TITLE
Version option in Renjin CLI

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -25,7 +25,8 @@ will help you quickly setup a Virtual Box with all the tools needed
 for Renjin's C/Fortran compile step.
 
 Install Vagrant from https://www.vagrantup.com and then run the following
-from the root of the Renjin git repository:
+from the root of the Renjin git repository that calls the
+[Vagrantfile](Vagrantfile):
 
     vagrant up
     vagrant ssh -c "cd /home/ubuntu/renjin && mvn clean install"

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -28,7 +28,7 @@ Install Vagrant from https://www.vagrantup.com and then run the following
 from the root of the Renjin git repository:
 
     vagrant up
-    vagrant ssh -c "cd renjin && mvn clean install"
+    vagrant ssh -c "cd /home/ubuntu/renjin && mvn clean install"
 
 Vagrant configures a shared directory on the VirtualBox guest machine
 that includes the Renjin repository, so once the initial build

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -44,7 +44,7 @@ Once you have run the build through Vagrant, then you should be able to
 make iterative changes to the Java sources and debug via your IDE 
 as normal.
 
-### Ubuntu 14.04+
+### Ubuntu 16.04+
 
 You can install the required tools through the APT package manager. 
 A 64-bit architecture is required.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,12 +4,15 @@
 # Vagrantfile API/syntax version
 VAGRANTFILE_API_VERSION = "2"
 
+# Override host locale variable
+ENV["LC_ALL"] = "en_US.UTF-8"
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.box = "ubuntu/xenial64"
   config.vm.provision :shell, inline: "apt-get update && apt-get install openjdk-8-jdk maven make gcc-4.7 gcc-4.7-plugin-dev gfortran-4.7 g++-4.7 gcc-4.7.multilib g++-4.7-multilib unzip -y"
   config.vm.synced_folder ".", "/home/ubuntu/renjin"
-  
+
   config.vm.provider "virtualbox" do |v|
     v.memory = 4096
     v.cpus = 2

--- a/cli/src/main/java/org/renjin/cli/Main.java
+++ b/cli/src/main/java/org/renjin/cli/Main.java
@@ -67,6 +67,11 @@ public class Main {
       OptionSet.printHelp(System.out);
       System.exit(0);
     }
+
+    if(optionSet.isVersionRequested()) {
+      OptionSet.printVersion(System.out);
+      System.exit(0);
+    }
     
     // Set process-wide flags
     if(optionSet.isFlagSet(OptionSet.COMPILE_LOOPS)) {

--- a/cli/src/main/java/org/renjin/cli/OptionSet.java
+++ b/cli/src/main/java/org/renjin/cli/OptionSet.java
@@ -69,10 +69,10 @@ public class OptionSet {
           this.helpRequested = true;
           break;
 
-				case "-v":
-				case "--version":
-					// TODO
-					break;
+	case "-v":
+	case "--version":
+		System.out.println("versie");
+	break;
 
         case PROFILE:
         case COMPILE_LOOPS:

--- a/cli/src/main/java/org/renjin/cli/OptionSet.java
+++ b/cli/src/main/java/org/renjin/cli/OptionSet.java
@@ -69,6 +69,11 @@ public class OptionSet {
           this.helpRequested = true;
           break;
 
+				case "-v":
+				case "--version":
+					// TODO
+					break;
+
         case PROFILE:
         case COMPILE_LOOPS:
           flags.add(option);

--- a/cli/src/main/java/org/renjin/cli/OptionSet.java
+++ b/cli/src/main/java/org/renjin/cli/OptionSet.java
@@ -69,10 +69,10 @@ public class OptionSet {
           this.helpRequested = true;
           break;
 
-	case "-v":
-	case "--version":
-		System.out.println("versie");
-	break;
+        case "-v":
+        case "--version":
+          System.out.println("versie");
+          break;
 
         case PROFILE:
         case COMPILE_LOOPS:

--- a/cli/src/main/java/org/renjin/cli/OptionSet.java
+++ b/cli/src/main/java/org/renjin/cli/OptionSet.java
@@ -21,6 +21,8 @@ package org.renjin.cli;
 import org.renjin.repackaged.guava.base.Charsets;
 import org.renjin.repackaged.guava.io.Resources;
 
+import org.renjin.RenjinVersion;
+
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.*;
@@ -38,6 +40,7 @@ public class OptionSet {
   private String file;
   
   private boolean helpRequested;
+  private boolean versionRequested;
 
   private String[] args;
   
@@ -71,7 +74,7 @@ public class OptionSet {
 
         case "-v":
         case "--version":
-          System.out.println("versie");
+          this.versionRequested = true;
           break;
 
         case PROFILE:
@@ -87,6 +90,10 @@ public class OptionSet {
 
   public boolean isHelpRequested() {
     return helpRequested;
+  }
+
+  public boolean isVersionRequested() {
+    return versionRequested;
   }
 
   /**
@@ -106,6 +113,11 @@ public class OptionSet {
   public static void printHelp(PrintStream out) throws IOException {
     String helpText = Resources.toString(Resources.getResource("help.txt"), Charsets.UTF_8);
     out.println(helpText);
+  }
+
+  public static void printVersion(PrintStream out) {
+    String versionText = RenjinVersion.getVersionName();
+    out.println("Renjin " + versionText);
   }
 
   public boolean hasExpression() {

--- a/cli/src/main/java/org/renjin/cli/OptionSet.java
+++ b/cli/src/main/java/org/renjin/cli/OptionSet.java
@@ -117,7 +117,7 @@ public class OptionSet {
 
   public static void printVersion(PrintStream out) {
     String versionText = RenjinVersion.getVersionName();
-    out.println("Renjin " + versionText);
+    out.println("renjin version " + versionText);
   }
 
   public boolean hasExpression() {

--- a/cli/src/main/resources/help.txt
+++ b/cli/src/main/resources/help.txt
@@ -7,7 +7,7 @@ specified options.
 
 Options:
   -h, --help            Print short help message and exit
-  -v, --version 				Show program version and exit
+  -v, --version         Show program version and exit
   --args                Skip the rest of the command line
   -f FILE, --file=FILE  Take input from 'FILE'
   -e EXPR               Execute 'EXPR' and exit

--- a/cli/src/main/resources/help.txt
+++ b/cli/src/main/resources/help.txt
@@ -7,6 +7,7 @@ specified options.
 
 Options:
   -h, --help            Print short help message and exit
+  -v, --version 				Show program version and exit
   --args                Skip the rest of the command line
   -f FILE, --file=FILE  Take input from 'FILE'
   -e EXPR               Execute 'EXPR' and exit
@@ -19,10 +20,10 @@ Execution flags:
   --compile-loops       Enable JIT compilation of loops (EXPERIMENTAL)
                         This is a work in progress and may still have bugs. 
 
-
 The most commonly used renjin commands are:
     help        Display help information
     package     Build an R package JAR from source
     batch-job   Build and deploy batch jobs to Renjin Batch Server
 
 See 'renjin help <command>' for more information on a specific command.
+


### PR DESCRIPTION
Closes #454 also included some suggestions & small improvements in building documentation and Vagrant setup.

NB: *GNU Coding Standards* has a nice list for the structure of command line arguments, e.g. [here](http://www.gnu.org/prep/standards/standards.html#g_t_002d_002dversion).