### PR TITLE
Add new line when quitting from renjin repl

### DIFF
--- a/cli/src/main/java/org/renjin/cli/Main.java
+++ b/cli/src/main/java/org/renjin/cli/Main.java
@@ -87,6 +87,8 @@ public class Main {
         Profiler.dump(System.out);
       }
     }
+    // print a new line when quit
+    System.out.println();
   }
 
   public Main(OptionSet options) {

--- a/repl/src/main/java/org/renjin/repl/JlineRepl.java
+++ b/repl/src/main/java/org/renjin/repl/JlineRepl.java
@@ -128,12 +128,12 @@ public class JlineRepl {
 
     try {
       while(readExpression()) { }
+
       // run finalizers and shutdown
       session.close();
 
     } finally {
       reader.getTerminal().restore();
-      reader.println();
     }
 
   }

--- a/repl/src/main/java/org/renjin/repl/JlineRepl.java
+++ b/repl/src/main/java/org/renjin/repl/JlineRepl.java
@@ -128,13 +128,14 @@ public class JlineRepl {
 
     try {
       while(readExpression()) { }
-
       // run finalizers and shutdown
       session.close();
 
     } finally {
       reader.getTerminal().restore();
+      reader.println();
     }
+
   }
 
   private void printGreeting() throws Exception {


### PR DESCRIPTION
In Renjin console, when pressing on <kbd>CTRL</kbd><kbd>D</kbd> (literally sending an `EOF` signal), a new line is not printed (unlike GNU R console). Therefore, the shell prompt followed after the quit is not displayed nicely.

```shell
metin@metin-ThinkPad-T470p:~$ renjin
Renjin 0.9.2725
Copyright (C) 2019 The R Foundation for Statistical Computing
Copyright (C) 2019 BeDataDriven
> 2 + 2
[1] 4
> metin@metin-ThinkPad-T470p:~$
metin@metin-ThinkPad-T470p:~$
```