### PR TITLE
add missing zlib to Vagrantfile

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -28,7 +28,7 @@ from the root of the Renjin git repository that calls the
 [Vagrantfile](Vagrantfile):
 
     vagrant up
-    vagrant ssh -c "cd /home/ubuntu/renjin && ./gradle build"
+    vagrant ssh -c "cd /home/ubuntu/renjin && ./gradlew build"
 
 Vagrant configures a shared directory on the VirtualBox guest machine
 that includes the Renjin repository, so once the initial build

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ ENV["LC_ALL"] = "en_US.UTF-8"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.box = "ubuntu/xenial64"
-  config.vm.provision :shell, inline: "apt-get update && apt-get install openjdk-8-jdk maven make gcc-4.7 gcc-4.7-plugin-dev gfortran-4.7 g++-4.7 gcc-4.7.multilib g++-4.7-multilib unzip -y"
+  config.vm.provision :shell, inline: "apt-get update && apt-get install openjdk-8-jdk maven make gcc-4.7 gcc-4.7-plugin-dev gfortran-4.7 g++-4.7 gcc-4.7.multilib g++-4.7-multilib unzip libz-dev -y"
   config.vm.synced_folder ".", "/home/ubuntu/renjin"
 
   config.vm.provider "virtualbox" do |v|


### PR DESCRIPTION
When I tried to build master i got a failure when building grDevices:

....
devPS.c:54:18: fatal error: zlib.h: No such file or directory
compilation terminated.
/home/ubuntu/renjin/tools/gnur-installation/src/main/resources/etc/Makeconf:169: recipe for target 'devPS.o' failed
make: *** [devPS.o] Error 1

> Task :packages:grDevices:make FAILED

.....

turns out libz-dev is not part of the Vagrantfile.

After doing
sudo apt-get install libz-dev

I managed to build everything just fine. By adding libz-dev to the Vagrantfile, this manual step should not be needed anymore.

Also changed the the build instruction for invoking ./gradle (does not exists) to ./gradlew (which does exist and works).