### PR TITLE
Dont escape printable non ascii chars in console and scriptengine

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -28,7 +28,7 @@ from the root of the Renjin git repository that calls the
 [Vagrantfile](Vagrantfile):
 
     vagrant up
-    vagrant ssh -c "cd /home/ubuntu/renjin && ./gradle build"
+    vagrant ssh -c "cd /home/ubuntu/renjin && ./gradlew build"
 
 Vagrant configures a shared directory on the VirtualBox guest machine
 that includes the Renjin repository, so once the initial build

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ ENV["LC_ALL"] = "en_US.UTF-8"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.box = "ubuntu/xenial64"
-  config.vm.provision :shell, inline: "apt-get update && apt-get install openjdk-8-jdk maven make gcc-4.7 gcc-4.7-plugin-dev gfortran-4.7 g++-4.7 gcc-4.7.multilib g++-4.7-multilib unzip -y"
+  config.vm.provision :shell, inline: "apt-get update && apt-get install openjdk-8-jdk maven make gcc-4.7 gcc-4.7-plugin-dev gfortran-4.7 g++-4.7 gcc-4.7.multilib g++-4.7-multilib unzip libz-dev -y"
   config.vm.synced_folder ".", "/home/ubuntu/renjin"
 
   config.vm.provider "virtualbox" do |v|

--- a/core/src/main/java/org/renjin/parser/StringLiterals.java
+++ b/core/src/main/java/org/renjin/parser/StringLiterals.java
@@ -24,6 +24,32 @@ import org.renjin.sexp.StringVector;
  * Formats
  */
 public class StringLiterals {
+
+
+    /** Whether to escape strings above codepoint 126 (non ascii) or not, defaults to false.
+     * Override with -D option or by setting a system variable for renjin.core.parser.escape.non.ascii
+     */
+    public static boolean ESCAPE_NON_ASCII = getPropertyOrEnv("renjin.core.parser.escape.non.ascii", "false")
+       .equalsIgnoreCase("true");
+
+    /**
+     * First check property (-D option), if that not exist then look for variable in the environment,
+     * if that does not exist either, then fallback to default.
+     * @param key the property key to look for, case sensitive
+     * @param defaultVal the fallback value if no key is defined
+     * @return the value corresponding to the property key or the defaultVal if none exist
+     */
+    private static String getPropertyOrEnv(String key, String defaultVal) {
+        String prop = System.getProperty(key);
+        if (prop == null) {
+            prop = System.getenv(key);
+        }
+        if (prop == null) {
+            return defaultVal;
+        }
+        return prop;
+    }
+
     /**
      * Formats a {@code String} as a literal
      *
@@ -66,7 +92,9 @@ public class StringLiterals {
                 buf.append("\\\"");
             } else if(codePoint == '\\') {
                 buf.append("\\\\");
-            } else if(codePoint < 32 || codePoint > 126) {
+            } else if(codePoint < 32) {
+                appendUnicodeEscape(buf, codePoint);
+            } else if (ESCAPE_NON_ASCII && codePoint  > 126) {
                 appendUnicodeEscape(buf, codePoint);
             } else {
                 buf.appendCodePoint(codePoint);

--- a/core/src/main/java/org/renjin/parser/StringLiterals.java
+++ b/core/src/main/java/org/renjin/parser/StringLiterals.java
@@ -26,30 +26,6 @@ import org.renjin.sexp.StringVector;
 public class StringLiterals {
 
 
-    /** Whether to escape strings above codepoint 126 (non ascii) or not, defaults to false.
-     * Override with -D option or by setting a system variable for renjin.core.parser.escape.non.ascii
-     */
-    public static boolean ESCAPE_NON_ASCII = getPropertyOrEnv("renjin.core.parser.escape.non.ascii", "false")
-       .equalsIgnoreCase("true");
-
-    /**
-     * First check property (-D option), if that not exist then look for variable in the environment,
-     * if that does not exist either, then fallback to default.
-     * @param key the property key to look for, case sensitive
-     * @param defaultVal the fallback value if no key is defined
-     * @return the value corresponding to the property key or the defaultVal if none exist
-     */
-    private static String getPropertyOrEnv(String key, String defaultVal) {
-        String prop = System.getProperty(key);
-        if (prop == null) {
-            prop = System.getenv(key);
-        }
-        if (prop == null) {
-            return defaultVal;
-        }
-        return prop;
-    }
-
     /**
      * Formats a {@code String} as a literal
      *
@@ -93,8 +69,6 @@ public class StringLiterals {
             } else if(codePoint == '\\') {
                 buf.append("\\\\");
             } else if(codePoint < 32) {
-                appendUnicodeEscape(buf, codePoint);
-            } else if (ESCAPE_NON_ASCII && codePoint  > 126) {
                 appendUnicodeEscape(buf, codePoint);
             } else {
                 buf.appendCodePoint(codePoint);

--- a/core/src/main/java/org/renjin/parser/StringLiterals.java
+++ b/core/src/main/java/org/renjin/parser/StringLiterals.java
@@ -68,7 +68,7 @@ public class StringLiterals {
                 buf.append("\\\"");
             } else if(codePoint == '\\') {
                 buf.append("\\\\");
-            } else if(codePoint < 32) {
+            } else if(codePoint < 32 || (codePoint > 126 && codePoint < 160)) {
                 appendUnicodeEscape(buf, codePoint);
             } else {
                 buf.appendCodePoint(codePoint);

--- a/core/src/test/java/org/renjin/parser/StringLiteralsTest.java
+++ b/core/src/test/java/org/renjin/parser/StringLiteralsTest.java
@@ -28,8 +28,10 @@ public class StringLiteralsTest {
     @Test
     public void unicodeEscapes() {
         assertThat(StringLiterals.format("\u0001", "NA"), equalTo("\"\\u0001\""));
-        assertThat(StringLiterals.format("\u00a1", "NA"), equalTo("\"\\u00a1\""));
-        assertThat(StringLiterals.format("\u01a1", "NA"), equalTo("\"\\u01a1\""));
-        assertThat(StringLiterals.format("\u1fa1", "NA"), equalTo("\"\\u1fa1\""));
+        assertThat(StringLiterals.format("\n", "NA"), equalTo("\"\\n\""));
+        assertThat(StringLiterals.format("åäö", "NA"), equalTo("\"åäö\""));
+        assertThat(StringLiterals.format("\u00a1", "NA"), equalTo("\"\u00a1\""));
+        assertThat(StringLiterals.format("\u01a1", "NA"), equalTo("\"\u01a1\""));
+        assertThat(StringLiterals.format("\u1fa1", "NA"), equalTo("\"\u1fa1\""));
     }
 }

--- a/core/src/test/java/org/renjin/parser/StringLiteralsTest.java
+++ b/core/src/test/java/org/renjin/parser/StringLiteralsTest.java
@@ -27,11 +27,21 @@ public class StringLiteralsTest {
 
     @Test
     public void unicodeEscapes() {
+        // Start of Heading should be escaped
         assertThat(StringLiterals.format("\u0001", "NA"), equalTo("\"\\u0001\""));
+        // newlines should be escaped
         assertThat(StringLiterals.format("\n", "NA"), equalTo("\"\\n\""));
+        // umlauts should NOT be escaped
         assertThat(StringLiterals.format("åäö", "NA"), equalTo("\"åäö\""));
+
+        // Inverted Exclamation Mark should NOT be escaped
         assertThat(StringLiterals.format("\u00a1", "NA"), equalTo("\"\u00a1\""));
+        // Latin Small Letter O with horn (ơ) should NOT be escaped
         assertThat(StringLiterals.format("\u01a1", "NA"), equalTo("\"\u01a1\""));
+        // greek small letter omega with dasia and ypogegrammeni (ᾡ) i.e. U+1FA1 should NOT be escaped
         assertThat(StringLiterals.format("\u1fa1", "NA"), equalTo("\"\u1fa1\""));
+
+        // Codepoint 149, Message Waiting, should be escaped
+        assertThat(StringLiterals.format("\u0095", "NA"), equalTo("\"\\u0095\""));
     }
 }

--- a/script-engine/build.gradle
+++ b/script-engine/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     compile project(':packages:datasets')
 }
 
-test.enabled = false
+test.enabled = true
 
 
 task combinedJavadoc(type: Javadoc) {

--- a/script-engine/src/test/java/org/renjin/script/CharacterTest.java
+++ b/script-engine/src/test/java/org/renjin/script/CharacterTest.java
@@ -1,0 +1,60 @@
+package org.renjin.script;
+
+import org.junit.Test;
+import org.renjin.parser.StringLiterals;
+import org.renjin.sexp.StringVector;
+
+import javax.script.ScriptException;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class CharacterTest {
+
+   @Test
+   public void testStdOut() throws IOException, ScriptException {
+      try (StringWriter outSw = new StringWriter();
+           PrintWriter outputWriter = new PrintWriter(outSw)) {
+         RenjinScriptEngine engine = new RenjinScriptEngine();
+         engine.getSession().setStdOut(outputWriter);
+
+         engine.eval("print('Hello World')");
+         assertThat(outSw.toString(), equalTo("[1] \"Hello World\"\n"));
+         outSw.getBuffer().setLength(0);
+         outSw.getBuffer().trimToSize();
+
+         engine.eval("print('åäö')");
+         assertThat(outSw.toString(), equalTo("[1] \"åäö\"\n"));
+      }
+   }
+
+   @Test
+   public void testNonAsciiWithVar() throws ScriptException {
+      RenjinScriptEngine engine = new RenjinScriptEngine();
+      engine.eval("charVar <- 'åäö'");
+      StringVector vec = (StringVector) engine.eval("charVar");
+      assertThat(vec.asString(), equalTo("åäö"));
+   }
+
+   @Test
+   public void testEscapeNonAsciiConfig() throws IOException, ScriptException {
+      StringLiterals.ESCAPE_NON_ASCII = true;
+      try (StringWriter outSw = new StringWriter();
+           PrintWriter outputWriter = new PrintWriter(outSw)) {
+         RenjinScriptEngine engine = new RenjinScriptEngine();
+         engine.getSession().setStdOut(outputWriter);
+
+         engine.eval("print('åäö')");
+         assertThat(outSw.toString(), equalTo("[1] \"\\u00e5\\u00e4\\u00f6\"\n"));
+         outSw.getBuffer().setLength(0);
+         outSw.getBuffer().trimToSize();
+
+         StringLiterals.ESCAPE_NON_ASCII = false;
+         engine.eval("print('åäö')");
+         assertThat(outSw.toString(), equalTo("[1] \"åäö\"\n"));
+      }
+   }
+}

--- a/script-engine/src/test/java/org/renjin/script/CharacterTest.java
+++ b/script-engine/src/test/java/org/renjin/script/CharacterTest.java
@@ -1,7 +1,6 @@
 package org.renjin.script;
 
 import org.junit.Test;
-import org.renjin.parser.StringLiterals;
 import org.renjin.sexp.StringVector;
 
 import javax.script.ScriptException;
@@ -26,8 +25,24 @@ public class CharacterTest {
          outSw.getBuffer().setLength(0);
          outSw.getBuffer().trimToSize();
 
+         engine.eval("cat('Hello\nWorld')");
+         assertThat(outSw.toString(), equalTo("Hello\nWorld"));
+         outSw.getBuffer().setLength(0);
+         outSw.getBuffer().trimToSize();
+
          engine.eval("print('åäö')");
          assertThat(outSw.toString(), equalTo("[1] \"åäö\"\n"));
+         outSw.getBuffer().setLength(0);
+         outSw.getBuffer().trimToSize();
+
+         engine.eval("cat('åäö')");
+         assertThat(outSw.toString(), equalTo("åäö"));
+
+         outSw.getBuffer().setLength(0);
+         outSw.getBuffer().trimToSize();
+
+         engine.eval("a <- '\u00b5';print(a)");
+         assertThat(outSw.toString(), equalTo("[1] \"µ\"\n"));
       }
    }
 
@@ -39,22 +54,4 @@ public class CharacterTest {
       assertThat(vec.asString(), equalTo("åäö"));
    }
 
-   @Test
-   public void testEscapeNonAsciiConfig() throws IOException, ScriptException {
-      StringLiterals.ESCAPE_NON_ASCII = true;
-      try (StringWriter outSw = new StringWriter();
-           PrintWriter outputWriter = new PrintWriter(outSw)) {
-         RenjinScriptEngine engine = new RenjinScriptEngine();
-         engine.getSession().setStdOut(outputWriter);
-
-         engine.eval("print('åäö')");
-         assertThat(outSw.toString(), equalTo("[1] \"\\u00e5\\u00e4\\u00f6\"\n"));
-         outSw.getBuffer().setLength(0);
-         outSw.getBuffer().trimToSize();
-
-         StringLiterals.ESCAPE_NON_ASCII = false;
-         engine.eval("print('åäö')");
-         assertThat(outSw.toString(), equalTo("[1] \"åäö\"\n"));
-      }
-   }
 }


### PR DESCRIPTION
Change escaping of code points to allow anything above 159. This will allow non ascii chars to be printed just like in Gnu R.