### PR TITLE
Treat CharSequences just like Strings 

### DIFF
--- a/core/src/main/java/org/renjin/invoke/reflection/converters/StringConverter.java
+++ b/core/src/main/java/org/renjin/invoke/reflection/converters/StringConverter.java
@@ -35,7 +35,7 @@ public class StringConverter extends BoxedScalarConverter<String> {
     if(clazz.isArray()) {
       return false;
     }
-    return clazz == String.class;
+    return clazz == String.class || clazz == CharSequence.class;
   }
   
   @Override

--- a/tests/src/main/java/org/renjin/invocation/StringParams.java
+++ b/tests/src/main/java/org/renjin/invocation/StringParams.java
@@ -1,0 +1,13 @@
+package org.renjin.invocation;
+
+/* Some methods with different parameters that we can call from R to make sure invocation works */
+public class StringParams {
+
+   public String concatCharSeq(CharSequence one, String two) {
+      return one + two;
+   }
+
+   public String concatString(String one, String two) {
+      return one + two;
+   }
+}

--- a/tests/src/test/R/test.invocations.R
+++ b/tests/src/test/R/test.invocations.R
@@ -1,0 +1,32 @@
+#
+# Renjin : JVM-based interpreter for the R language for the statistical analysis
+# Copyright © 2010-2019 BeDataDriven Groep B.V. and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, a copy is available at
+# https://www.gnu.org/licenses/gpl-2.0.txt
+#
+
+library(hamcrest)
+
+test.stringparams <- function() {
+   import(org.renjin.invocation.StringParams)
+   strParms <- StringParams$new()
+   assertThat(strParms$concatString("Hello ", "World"), equalTo("Hello World"))
+}
+
+test.charseq <- function() {
+   import(org.renjin.invocation.StringParams)
+   strParms <- StringParams$new()
+   assertThat(strParms$concatCharSeq("Hello ", "World2"), equalTo("Hello World2"))
+}


### PR DESCRIPTION
Treat CharSequences just like Strings so that calling java code taking a charsequence as method parameter works.

Without the fix a java metod taking e.g. a CharSequence and a String as parameters would result in
org.renjin.eval.EvalException: Cannot match arguments (character, character) to any JVM method overload:

It is a rather simple fix (maybe too simple) but seems to work fine. An alternative would be to create a separate CharSequenceConverter but could not think of a use case to warrant that.  

Created a test to verify that the fix works.