### PR TITLE
Implement rotate right

### DIFF
--- a/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/expr/ExprFactory.java
+++ b/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/expr/ExprFactory.java
@@ -343,6 +343,7 @@ public class ExprFactory {
       case LSHIFT_EXPR:
       case RSHIFT_EXPR:
       case LROTATE_EXPR:
+      case RROTATE_EXPR:
         return findBinaryGenerator(op, operands);
 
       case POINTER_PLUS_EXPR:
@@ -469,6 +470,9 @@ public class ExprFactory {
 
       case LROTATE_EXPR:
         return x.toPrimitiveExpr().toIntExpr().rotateLeft(y);
+
+      case RROTATE_EXPR:
+        return x.toPrimitiveExpr().toIntExpr().rotateRight(y);
 
     }
     return null;

--- a/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/BooleanExpr.java
+++ b/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/BooleanExpr.java
@@ -103,6 +103,11 @@ public class BooleanExpr extends AbstractPrimitiveExpr implements IntExpr {
     throw new UnsupportedOperationException();
   }
 
+  @Override
+  public GExpr rotateRight(GExpr operand) {
+    throw new UnsupportedOperationException();
+  }
+
   public UnsignedSmallIntExpr toUnsignedByteExpr() {
     return new UnsignedSmallIntExpr(8, jexpr());
   }

--- a/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/IntExpr.java
+++ b/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/IntExpr.java
@@ -39,6 +39,8 @@ public interface IntExpr extends PrimitiveExpr {
 
   GExpr rotateLeft(GExpr operand);
 
+  GExpr rotateRight(GExpr operand);
+
   IntExpr toSignedInt(int precision);
 
 }

--- a/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/PtrCarryingExpr.java
+++ b/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/PtrCarryingExpr.java
@@ -191,6 +191,12 @@ public class PtrCarryingExpr implements NumericIntExpr {
   }
 
   @Override
+  public GExpr rotateRight(GExpr operand) {
+    // Relationship to pointer is lost
+    return primitive.rotateRight(operand);
+  }
+
+  @Override
   public IntExpr toSignedInt(int precision) {
     if(precision < 32) {
       // Relationship to pointer is lost

--- a/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/ShortExpr.java
+++ b/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/ShortExpr.java
@@ -138,6 +138,11 @@ public class ShortExpr extends AbstractIntExpr implements IntExpr {
   }
 
   @Override
+  public ShortExpr rotateRight(GExpr operand) {
+    throw new UnsupportedOperationException("TODO");
+  }
+
+  @Override
   public GimplePrimitiveType getType() {
     return new GimpleIntegerType(16);
   }

--- a/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/SignedByteExpr.java
+++ b/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/SignedByteExpr.java
@@ -135,6 +135,10 @@ public class SignedByteExpr extends AbstractIntExpr implements IntExpr {
     throw new UnsupportedOperationException("TODO");
   }
 
+  @Override
+  public SignedByteExpr rotateRight(GExpr operand) {
+    throw new UnsupportedOperationException("TODO");
+  }
 
   @Override
   public GimplePrimitiveType getType() {

--- a/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/SignedIntExpr.java
+++ b/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/SignedIntExpr.java
@@ -138,6 +138,11 @@ public class SignedIntExpr extends AbstractIntExpr {
   }
 
   @Override
+  public IntExpr rotateRight(GExpr operand) {
+    return lift(Expressions.staticMethodCall(Integer.class, "rotateRight", "(II)I", jexpr(), jexpr(operand)));
+  }
+
+  @Override
   public GimplePrimitiveType getType() {
     return new GimpleIntegerType(32);
   }

--- a/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/SignedLongExpr.java
+++ b/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/SignedLongExpr.java
@@ -124,6 +124,11 @@ public class SignedLongExpr extends AbstractIntExpr {
     return lift(Expressions.staticMethodCall(Long.class, "rotateLeft", "(JI)J", jexpr(), bits(operand)));
   }
 
+  @Override
+  public SignedLongExpr rotateRight(GExpr operand) {
+    return lift(Expressions.staticMethodCall(Long.class, "rotateRight", "(JI)J", jexpr(), bits(operand)));
+  }
+
   public IntExpr toSignedInt32() {
     return new SignedIntExpr(Expressions.l2i(jexpr()));
   }

--- a/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/UnsignedIntExpr.java
+++ b/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/UnsignedIntExpr.java
@@ -138,6 +138,11 @@ public class UnsignedIntExpr extends AbstractIntExpr {
   }
 
   @Override
+  public UnsignedIntExpr rotateRight(GExpr operand) {
+    return lift(Expressions.staticMethodCall(Integer.class, "rotateRight", "(II)I", jexpr(), bits(operand)));
+  }
+
+  @Override
   public GimplePrimitiveType getType() {
     return GimpleIntegerType.unsigned(32);
   }

--- a/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/UnsignedLongExpr.java
+++ b/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/UnsignedLongExpr.java
@@ -134,6 +134,11 @@ public class UnsignedLongExpr extends AbstractIntExpr {
   }
 
   @Override
+  public GExpr rotateRight(GExpr operand) {
+    return lift(Expressions.staticMethodCall(Long.class, "rotateRight", "(JI)J", jexpr(), bits(operand)));
+  }
+
+  @Override
   public IntExpr toSignedInt(int precision) {
     switch (precision) {
       case 64:

--- a/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/UnsignedSmallIntExpr.java
+++ b/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/UnsignedSmallIntExpr.java
@@ -151,6 +151,11 @@ public class UnsignedSmallIntExpr extends AbstractIntExpr {
   }
 
   @Override
+  public UnsignedSmallIntExpr rotateRight(GExpr operand) {
+    throw new UnsupportedOperationException("TODO");
+  }
+
+  @Override
   public GimplePrimitiveType getType() {
     return GimpleIntegerType.unsigned(precision);
   }


### PR DESCRIPTION
Add rotateRight() to IntExpr. Add implementations for all implementing types where rotateLeft() is already implemented and add stubs on others.