### PR TITLE
Update GCC to 4.8 for the bridge plugin

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,10 +9,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - name: Install build dependencies
-      run: sudo apt-get install openjdk-8-jdk make gcc-4.7 gcc-4.7-plugin-dev gfortran-4.7 g++-4.7 gcc-4.7.multilib g++-4.7-multilib libz-dev
+      run: sudo apt-get install openjdk-8-jdk make gcc-4.8 gcc-4.8-plugin-dev gfortran-4.8 g++-4.8 gcc-4.8.multilib g++-4.8-multilib libz-dev
     - name: Build with Gradle
       run: ./gradlew build check

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -9,13 +9,13 @@ In addition to the standard Java tools, Renjin relies on a GCC-based
 build chain to compile C/Fortran math routines to JVM byte code.
 These tools are under active development and are
 sensitive to different versions of GCC. The current version of Renjin
-requires GCC 4.7.x.
+requires GCC 4.8.x.
 
 
 Requirements
 ------------
 1. JDK 1.8 Recommended
-2. GCC 4.7
+2. GCC 4.8
 
 ### Vagrant
 
@@ -44,12 +44,12 @@ Once you have run the build through Vagrant, then you should be able to
 make iterative changes to the Java sources and debug via your IDE 
 as normal.
 
-### Ubuntu 16.04+
+### Ubuntu 18.04+
 
 You can install the required tools through the APT package manager. 
 A 64-bit architecture is required.
 
-    sudo apt-get install openjdk-8-jdk make gcc-4.7 gcc-4.7-plugin-dev gfortran-4.7 g++-4.7 gcc-4.7.multilib g++-4.7-multilib libz-dev
+    sudo apt-get install openjdk-8-jdk make gcc-4.8 gcc-4.8-plugin-dev gfortran-4.8 g++-4.8 gcc-4.8.multilib g++-4.8-multilib libz-dev
 
 Then build:
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,8 +9,8 @@ ENV["LC_ALL"] = "en_US.UTF-8"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.box = "ubuntu/xenial64"
-  config.vm.provision :shell, inline: "apt-get update && apt-get install openjdk-8-jdk maven make gcc-4.7 gcc-4.7-plugin-dev gfortran-4.7 g++-4.7 gcc-4.7.multilib g++-4.7-multilib unzip libz-dev -y"
+  config.vm.box = "ubuntu/bionic64"
+  config.vm.provision :shell, inline: "apt-get update && apt-get install openjdk-8-jdk maven make gcc-4.8 gcc-4.8-plugin-dev gfortran-4.8 g++-4.8 gcc-4.8.multilib g++-4.8-multilib unzip libz-dev -y"
   config.vm.synced_folder ".", "/home/ubuntu/renjin"
 
   config.vm.provider "virtualbox" do |v|

--- a/math/compile.gradle
+++ b/math/compile.gradle
@@ -60,7 +60,7 @@ if(fortranDir.exists()) {
                 if (sourceFile.name.endsWith('.f')) {
                     project.exec {
                         workingDir tempDir
-                        executable 'gfortran-4.7'
+                        executable 'gfortran-4.8'
                         args '-m32'
                         args '-D_GCC_BRIDGE', '-D_RENJIN'
                         args '-c'
@@ -93,7 +93,7 @@ if(cDir.exists()) {
                 if (sourceFile.name.endsWith('.c')) {
                     project.exec {
                         workingDir tempDir
-                        executable 'gcc-4.7'
+                        executable 'gcc-4.8'
                         args '-m32'
                         args '-D_GCC_BRIDGE', '-D_RENJIN'
                         args '-c'

--- a/tools/gcc-bridge/compiler/build.gradle
+++ b/tools/gcc-bridge/compiler/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 task compilePlugin(type: Exec) {
 
     def sourceFile = 'src/main/resources/org/renjin/gcc/plugin.c'
-    def gcc = 'gcc-4.7'
+    def gcc = 'gcc-4.8'
 
     inputs.file sourceFile
     outputs.file gccBridgePlugin

--- a/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/Gcc.java
+++ b/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/Gcc.java
@@ -184,7 +184,7 @@ public class Gcc {
    */
   private String callGcc(List<String> arguments) throws IOException {
     List<String> command = Lists.newArrayList();
-    command.add("gcc-4.7");
+    command.add("gcc-4.8");
     command.addAll(arguments);
 
     System.err.println("EXECUTING: " + Joiner.on(" ").join(arguments));

--- a/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/PrimitiveType.java
+++ b/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/PrimitiveType.java
@@ -134,6 +134,38 @@ public enum PrimitiveType {
       return new RealExpr(gimpleType(), Expressions.constantDouble(((GimpleRealConstant) expr).getValue()));
     }
   },
+  REAL128 {
+
+    @Override
+    public GimpleRealType gimpleType() {
+      return new GimpleRealType(128);
+    }
+
+    @Override
+    public Type jvmType() {
+      return Type.DOUBLE_TYPE;
+    }
+
+    @Override
+    public String javaTypeName() {
+      return "double";
+    }
+
+    @Override
+    public PrimitiveExpr cast(PrimitiveExpr x) {
+      return x.toReal(128);
+    }
+
+    @Override
+    public PrimitiveExpr fromStackValue(JExpr jExpr, @Nullable PtrExpr address) {
+      return new RealExpr(gimpleType(), jExpr, address);
+    }
+
+    @Override
+    public GExpr constantExpr(GimpleConstant expr) {
+      return new RealExpr(gimpleType(), Expressions.constantDouble(((GimpleRealConstant) expr).getValue()));
+    }
+  },
   BOOL {
     @Override
     public GimplePrimitiveType gimpleType() {
@@ -484,6 +516,8 @@ public enum PrimitiveType {
           return REAL64;
         case 96:
           return REAL96;
+        case 128:
+          return REAL128;
       }
     } else if(type instanceof GimpleIntegerType) {
       GimpleIntegerType integerType = (GimpleIntegerType) type;

--- a/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/RealExpr.java
+++ b/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/codegen/type/primitive/RealExpr.java
@@ -244,7 +244,8 @@ public class RealExpr extends AbstractPrimitiveExpr implements NumericExpr {
   private JExpr jexpr(int targetPrecision) {
     if(this.getPrecision() == targetPrecision ||
         (this.getPrecision() == 64 && targetPrecision == 96) ||
-        (this.getPrecision() == 96 && targetPrecision == 64)) {
+        (this.getPrecision() == 96 && targetPrecision == 64) ||
+        (this.getPrecision() == 128 && targetPrecision == 64)) {
       return jexpr();
     } else if(this.getPrecision() == 32 && (targetPrecision == 64 || targetPrecision == 96)) {
       return Expressions.f2d(jexpr());

--- a/tools/gcc-bridge/compiler/src/main/resources/org/renjin/gcc/plugin.c
+++ b/tools/gcc-bridge/compiler/src/main/resources/org/renjin/gcc/plugin.c
@@ -1131,10 +1131,11 @@ static void dump_global_vars() {
   json_array_field("globalVariables");
     
   struct varpool_node *node;
-  for (node = varpool_nodes; node; node = node->next)
-    {
-        dump_global_var(node->decl);
-    }
+  node = varpool_first_variable();
+  for (node = varpool_first_variable (); node; node = varpool_next_variable (node))
+  {
+        dump_global_var(node->symbol.decl);
+  }
 
   json_end_array();
 }
@@ -1156,12 +1157,12 @@ static void dump_aliases() {
   struct cgraph_node *n;
 
   FOR_EACH_DEFINED_FUNCTION(n) {
-    if (DECL_ASSEMBLER_NAME_SET_P (n->decl)) {
+    if (DECL_ASSEMBLER_NAME_SET_P (n->symbol.decl)) {
       if(n->alias && n->thunk.alias) {
           json_start_object();
-          json_string_field("alias",  IDENTIFIER_POINTER(DECL_ASSEMBLER_NAME(n->decl)));
+          json_string_field("alias",  IDENTIFIER_POINTER(DECL_ASSEMBLER_NAME(n->symbol.decl)));
           json_string_field("definition",  IDENTIFIER_POINTER(DECL_ASSEMBLER_NAME(n->thunk.alias)));
-          json_bool_field("public", TREE_PUBLIC(n->decl));
+          json_bool_field("public", TREE_PUBLIC(n->symbol.decl));
           json_end_object();
       }
     }
@@ -1196,13 +1197,14 @@ static struct gimple_opt_pass dump_functions_pass =
     {
       GIMPLE_PASS,
       "json", 	      /* pass name */
+      OPTGROUP_NONE,  /* optinfo_flags */
       NULL,	          /* gate */
       dump_function,	/* execute */
       NULL,		        /* sub */
       NULL,		        /* next */
       0,		          /* static_pass_number */
       TV_NONE,	         /* tv_id */
-      PROP_cfg | PROP_referenced_vars,   		/* properties_required */
+      PROP_cfg, /*| PROP_referenced_vars,*/   		/* properties_required */
       0,		          /* properties_provided */
       0,		          /* properties_destroyed */
       0,		          /* todo_flags_start */

--- a/tools/gcc-bridge/runtime/src/main/java/org/renjin/gcc/runtime/Stdlib.java
+++ b/tools/gcc-bridge/runtime/src/main/java/org/renjin/gcc/runtime/Stdlib.java
@@ -1337,6 +1337,10 @@ public class Stdlib {
     return x < 0;
   }
 
+  public static boolean __signbitf128(double x) {
+    return x < 0;
+  }
+
   /**
    * Returns the value of an environment variable.
    */

--- a/tools/gnur-installation/src/main/resources/bin/R
+++ b/tools/gnur-installation/src/main/resources/bin/R
@@ -20,23 +20,23 @@ fi
 
 case "$3" in
     F77)
-        echo gfortran-4.7
+        echo gfortran-4.8
         ;;
     FC)
-        echo gfortran-4.7
+        echo gfortran-4.8
         ;;
     CC)
-        echo gcc-4.7
+        echo gcc-4.8
         ;;
 
     CPP)
-        echo cpp-4.7
+        echo cpp-4.8
         ;;
     CXX)
-        echo g++-4.7
+        echo g++-4.8
         ;;
     CXX1X)
-        echo g++-4.7
+        echo g++-4.8
         ;;
     CXX1XSTD)
         echo -std=c++11

--- a/tools/gnur-installation/src/main/resources/etc/Makeconf
+++ b/tools/gnur-installation/src/main/resources/etc/Makeconf
@@ -13,23 +13,23 @@ include $(R_SHARE_DIR)/make/vars.mk
 AR = ar
 BLAS_LIBS = -lblas
 C_VISIBILITY = -fvisibility=hidden
-CC = gcc-4.7 -std=gnu99
+CC = gcc-4.8 -std=gnu99
 CFLAGS = ${RENJIN_FLAGS} -g ${OPT_FLAGS} $(LTO)
 CPICFLAGS = -fpic
 CPPFLAGS =
-CXX = g++-4.7
+CXX = g++-4.8
 CXXCPP = $(CXX) -E
 CXXFLAGS = ${RENJIN_FLAGS} -g ${OPT_FLAGS} $(LTO)
 CXXPICFLAGS = -fpic
-CXX98 = g++-4.7
+CXX98 = g++-4.8
 CXX98FLAGS = ${RENJIN_FLAGS} -g ${OPT_FLAGS}
 CXX98PICFLAGS = -fpic
 CXX98STD = -std=gnu++98
-CXX11 = g++-4.7
+CXX11 = g++-4.8
 CXX11FLAGS = ${RENJIN_FLAGS} -g ${OPT_FLAGS}
 CXX11PICFLAGS = -fpic
 CXX11STD = -std=gnu++11
-CXX14 = g++-4.7
+CXX14 = g++-4.8
 CXX14FLAGS = ${RENJIN_FLAGS} -g ${OPT_FLAGS}
 CXX14PICFLAGS = -fpic
 CXX14STD = -std=gnu++14
@@ -48,12 +48,12 @@ ECHO_N = -n
 ECHO_T = 
 ## NB, set FC before F77 as on Solaris make, setting FC sets F77
 ## FC is the compiler used for free-form Fortran, exts .f90/.f95
-FC = gfortran-4.7
+FC = gfortran-4.8
 FCFLAGS = -g ${OPT_FLAGS} $(LTO)
 ## additional libs needed when linking with $(FC), e.g. on some Oracle compilers
 FCLIBS =
 ## F77 is the compiler used for fixed-form Fortran, ext .f
-F77 = gfortran-4.7
+F77 = gfortran-4.8
 F77_VISIBILITY = -fvisibility=hidden
 F_VISIBILITY = -fvisibility=hidden
 FFLAGS = ${RENJIN_FLAGS} -g ${OPT_FLAGS} $(LTO)
@@ -137,7 +137,7 @@ TCLTK_LIBS = -L/usr/lib/x86_64-linux-gnu -ltcl8.6 -L/usr/lib/x86_64-linux-gnu -l
 YACC = bison -y
 
 ## legacy
-CXX1X = g++-4.7
+CXX1X = g++-4.8
 CXX1XFLAGS = ${RENJIN_FLAGS} -g
 CXX1XPICFLAGS = -fpic
 CXX1XSTD = -std=gnu++11


### PR DESCRIPTION
I'm trying to upgrade GCC to 4.8, so that I can build and use at least the gcc-bridge plugin on a more recent Ubuntu where gcc-4.7 is not available but gcc-4.8 is. The tests almost pass, just 2 fail: `sha256` and `signbit`. Any idea what's going on? Is this going to be hard to fix?