### PR TITLE
#522, remove the isWindows() check for Sys.which since it works fine in windows

### DIFF
--- a/core/src/main/java/org/renjin/primitives/files/Files.java
+++ b/core/src/main/java/org/renjin/primitives/files/Files.java
@@ -302,10 +302,6 @@ public class Files {
   @Internal("Sys.which")
   public static StringVector sysWhich(@Current Context context, StringVector names) {
 
-    if(isWindows()) {
-      throw new EvalException("Sys.which() not implemented for Windows");
-    }
-
     String[] path = Strings.nullToEmpty(System.getenv("PATH")).split(File.pathSeparator);
 
     StringVector.Builder result = new StringArrayVector.Builder(0, names.length());


### PR DESCRIPTION
resolves #522

Example:

Renjin 3.5-dev
Copyright (C) 2019 The R Foundation for Statistical Computing
Copyright (C) 2021 BeDataDriven
Using native reference BLAS libraries.

Sys.which("cmd.exe")
cmd.exe
"/C:/WINDOWS/system32/cmd.exe"