### PR TITLE
Bug Fix: Added missing MixedPtr.setPointer(Ptr;) method

### DIFF
--- a/tools/gcc-bridge/runtime/src/main/java/org/renjin/gcc/runtime/MixedPtr.java
+++ b/tools/gcc-bridge/runtime/src/main/java/org/renjin/gcc/runtime/MixedPtr.java
@@ -123,6 +123,11 @@ public class MixedPtr extends AbstractPtr {
 
     return BytePtr.NULL.pointerPlus(getInt(offset));
   }
+  
+  @Override
+  public final void setPointer(Ptr value) {
+    super.setPointer(value);
+  }
 
   @Override
   public final void setPointer(int offset, Ptr value) {


### PR DESCRIPTION
The method setPointer(value) is defined in the AbstractPtr class (https://github.com/bedatadriven/renjin/blob/cac412d232ad66d4ee8e37cfc8cb70a45e676e19/tools/gcc-bridge/runtime/src/main/java/org/renjin/gcc/runtime/AbstractPtr.java#L276-L279) but was forgotten to be implemented in the MixedPtr class.