### PR TITLE
Improve sessionInfo() and La_library()

### DIFF
--- a/core/src/main/R/renjinBase/La_library.R
+++ b/core/src/main/R/renjinBase/La_library.R
@@ -17,6 +17,9 @@
 # https://www.gnu.org/licenses/gpl-2.0.txt
 #
 
-#  A character vector of length one (‘""’ when the name is not known).
+#  A character vector of the java class that is handling the LAPACK (NativeRef, NativeSystem, F2j).
 
-La_library <- function() ""
+La_library <- function() {
+  import(com.github.fommil.netlib.LAPACK)
+  return(LAPACK$getInstance()$getClass()$getName())
+}

--- a/core/src/main/R/renjinBase/New-Internal.R
+++ b/core/src/main/R/renjinBase/New-Internal.R
@@ -89,8 +89,18 @@ icuGetCollate <- function(type = c("actual", "valid"))
     stop("icuGetCollate() not supported by Renjin")
 
 extSoftVersion <- function() {
-    warning("Renjin does not support extSoftVersion()")
-    list()
+    import(com.github.fommil.netlib.BLAS)
+    c(
+      "zlib" = "",
+      "bzlib" = "",
+      "xz" = "",
+      "PCRE" = "",
+      "ICU" = "",
+      "TRE" = "",
+      "iconv" = "",
+      "readline" = "",
+      "BLAS" = BLAS$getInstance()$getClass()$getName()
+    )
 }
 
 libcurlVersion <- function() {

--- a/packages/utils/NAMESPACE
+++ b/packages/utils/NAMESPACE
@@ -43,7 +43,7 @@ export("?", .DollarNames, .S3methods, .romans, CRAN.packages, Rprof,
        toBibtex, toLatex, type.convert, undebugcall, unstack, untar, unzip,
        ## update.packageStatus,
        update.packages, upgrade, url.show, vi,
-       vignette, warnErrList, write.csv, write.csv2, write.socket, write.table,
+       vignette, warnErrList, win.version, write.csv, write.csv2, write.socket, write.table,
        xedit, xemacs, zip)
 
 export(txtProgressBar, getTxtProgressBar, setTxtProgressBar)

--- a/packages/utils/R/sessionInfo.R
+++ b/packages/utils/R/sessionInfo.R
@@ -78,6 +78,11 @@ sessionInfo <- function(package = NULL)
                    },
                    uname)
     }
+    # If the above failed for some reason, fall back to System properties
+    if (z$running == 0 || is.null(z$running)) {
+        import(java.lang.System)
+        z$running <- paste(System$getProperty("os.name"), System$getProperty("os.version"))
+    }
 
     if(is.null(package)){
         package <- grep("^package:", search(), value=TRUE)

--- a/packages/utils/R/winextras.R
+++ b/packages/utils/R/winextras.R
@@ -1,0 +1,23 @@
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  A copy of the GNU General Public License is available at
+#  http://www.r-project.org/Licenses/
+
+# In GNU R win.version is based on the Windows GetVersionEx API function
+# Here we use system properties to achive a similar result
+win.version <- function() {
+  import(java.lang.System)
+  paste(
+    System$getProperty("os.name"),
+    System$getProperty("os.arch"),
+    paste0("(", System$getProperty("os.version"), ")")
+  )
+}


### PR DESCRIPTION
- Provide slightly more info to La_library()
- Crude implementation of extSoftVersion 
- In sessionInfo(): Add catch if system("uname -a") does not return anything meaningful (on Linux Mint this works fine in R but fails in Renjin (it returns 0)) and fallback to System properties.
- add win.version() so that sessionInfo also works on windows.