### PR TITLE
upgrade dependencies

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision :shell, inline: "apt-get update && apt-get install openjdk-8-jdk maven make gcc-4.7 gcc-4.7-plugin-dev gfortran-4.7 g++-4.7 gcc-4.7.multilib g++-4.7-multilib unzip libz-dev -y"
   config.vm.synced_folder ".", "/home/ubuntu/renjin"
 
+  # So we can do ./gradlew publishToMavenLocal and also save some disk space
+  config.vm.synced_folder "~/.m2", "/home/vagrant/.m2"
+
   config.vm.provider "virtualbox" do |v|
     v.memory = 4096
     v.cpus = 2

--- a/appengine/build.gradle
+++ b/appengine/build.gradle
@@ -4,8 +4,8 @@ apply from: "../gradle/maven.gradle"
 
 dependencies {
     compile project(':script-engine')
-    compileOnly 'javax.servlet:javax.servlet-api:3.0.1'
-    testCompile 'org.easymock:easymock:3.3'
-    testCompile 'javax.servlet:javax.servlet-api:3.0.1'
+    compileOnly 'javax.servlet:javax.servlet-api:4.0.1'
+    testCompile 'org.easymock:easymock:4.3'
+    testCompile 'javax.servlet:javax.servlet-api:4.0.1'
 
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -32,8 +32,8 @@ dependencies {
     compile 'org.apache.commons:commons-math:2.2'
     compile 'com.github.fommil.netlib:core:1.1.2'
     compile 'org.apache.commons:commons-vfs2:2.0'
-    compile 'org.apache.commons:commons-compress:1.18'
-    compile 'org.tukaani:xz:1.8'
+    compile 'org.apache.commons:commons-compress:1.21'
+    compile 'org.tukaani:xz:1.9'
 
     compile libraries.asm
     compile libraries.guava

--- a/core/src/main/java/org/renjin/primitives/files/Files.java
+++ b/core/src/main/java/org/renjin/primitives/files/Files.java
@@ -378,7 +378,7 @@ public class Files {
    * @return true if the operation succeeded for each of the files attempted.
    *  Using a missing value for a path name will always be regarded as a failure.
    *  returns false if the directory already exists
-   * @throws FileSystemException
+   * @throws FileSystemException if FileObject.createFolder failed
    */
   @Internal("dir.create")
   public static SEXP dirCreate(@Current Context context, String path, boolean showWarnings, boolean recursive, int mode) throws FileSystemException {
@@ -395,7 +395,7 @@ public class Files {
    * Checks if input directory exists.
 
    * @param context the current call Context
-   * @param paths character vectors containing file or directory paths.
+   * @param uri character vectors containing file or directory paths.
    *              Tilde expansion (see ‘path.expand’) is done.
    * @return true if the operation succeeded for each of the directory attempted.
    *  Using a missing value for a path name will always be regarded as a failure.

--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -14,13 +14,13 @@ ext {
         asm:                "org.renjin:renjin-asm:5.0.4b",
         airline:            'io.airlift:airline:0.9',
         slf4j: [
-            api:            'org.slf4j:slf4j-api:1.6.1',
-            impl:           'org.slf4j:slf4j-jdk14:1.6.1'
+            api:            'org.slf4j:slf4j-api:1.7.35',
+            impl:           'org.slf4j:slf4j-jdk14:1.7.35'
         ],
 
-        junit:              'junit:junit:4.13.1',
+        junit:              'junit:junit:4.13.2',
         hamcrest:           'org.hamcrest:hamcrest-library:1.3',
-        easymock:           'org.easymock:easymock:3.1'
+        easymock:           'org.easymock:easymock:4.3'
     ]
 }
 

--- a/packages/grDevices/build.gradle
+++ b/packages/grDevices/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     compile project(':core')
     compile project(':tools:gnur-runtime')
 
-    compile 'org.jfree:jfreesvg:3.3'
+    compile 'org.jfree:jfreesvg:3.4.2'
 
     testCompile project(':packages:hamcrest')
 }

--- a/packages/grDevices/java/org/renjin/grDevices/GraphicsDevices.java
+++ b/packages/grDevices/java/org/renjin/grDevices/GraphicsDevices.java
@@ -44,7 +44,7 @@ public class GraphicsDevices {
 
     String deviceClassName = Stdlib.nullTerminatedString(deviceClassPtr);
 
-    Class deviceClass;
+    Class<?> deviceClass;
     try {
       deviceClass = Class.forName(deviceClassName);
     } catch (ClassNotFoundException e) {
@@ -53,7 +53,7 @@ public class GraphicsDevices {
 
     GraphicsDevice device;
     try {
-      Constructor constructor = deviceClass.getConstructor(Session.class, ListVector.class);
+      Constructor<?> constructor = deviceClass.getConstructor(Session.class, ListVector.class);
       Session session = Native.currentContext().getSession();
       device = (GraphicsDevice) constructor.newInstance(session, deviceOptions);
     } catch (Exception e) {

--- a/tools/aether-package-loader/build.gradle
+++ b/tools/aether-package-loader/build.gradle
@@ -1,7 +1,6 @@
 
-def aetherVersion = "1.0.2.v20150114"
-def mavenVersion = "3.1.0"
-def wagonVersion = "1.0"
+def aetherVersion = "1.1.0"
+def mavenVersion = "3.3.9"
 
 dependencies {
     compile project(":core")
@@ -14,5 +13,6 @@ dependencies {
     compile "org.eclipse.aether:aether-transport-http:${aetherVersion}"
     compile "org.apache.maven:maven-aether-provider:${mavenVersion}"
     compile "org.apache.maven:maven-settings-builder:${mavenVersion}"
-    compile "org.json:json:20180130"
+    compile "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5"
+    compile "org.json:json:20211205"
 }

--- a/tools/aether-package-loader/src/main/java/org/renjin/aether/MavenSettingsDecrypter.java
+++ b/tools/aether-package-loader/src/main/java/org/renjin/aether/MavenSettingsDecrypter.java
@@ -35,14 +35,12 @@ import java.util.List;
 public class MavenSettingsDecrypter implements SettingsDecrypter {
 
   // Copied from Maven as there was no constructor to set the security Dispatcher
-
-  private SecDispatcher securityDispatcher = new MavenSecDispatcher();
-
+  private final SecDispatcher securityDispatcher = new MavenSecDispatcher();
 
   public SettingsDecryptionResult decrypt(SettingsDecryptionRequest request) {
-    List<SettingsProblem> problems = new ArrayList<SettingsProblem>();
+    List<SettingsProblem> problems = new ArrayList<>();
 
-    List<Server> servers = new ArrayList<Server>();
+    List<Server> servers = new ArrayList<>();
 
     for (Server server : request.getServers()) {
       server = server.clone();
@@ -64,7 +62,7 @@ public class MavenSettingsDecrypter implements SettingsDecrypter {
       }
     }
 
-    List<Proxy> proxies = new ArrayList<Proxy>();
+    List<Proxy> proxies = new ArrayList<>();
 
     for (Proxy proxy : request.getProxies()) {
       proxy = proxy.clone();
@@ -97,9 +95,9 @@ public class MavenSettingsDecrypter implements SettingsDecrypter {
     private List<SettingsProblem> problems;
 
     public DefaultSettingsDecryptionResult(List<Server> servers, List<Proxy> proxies, List<SettingsProblem> problems) {
-      this.servers = (servers != null) ? servers : new ArrayList<Server>();
-      this.proxies = (proxies != null) ? proxies : new ArrayList<Proxy>();
-      this.problems = (problems != null) ? problems : new ArrayList<SettingsProblem>();
+      this.servers = (servers != null) ? servers : new ArrayList<>();
+      this.proxies = (proxies != null) ? proxies : new ArrayList<>();
+      this.problems = (problems != null) ? problems : new ArrayList<>();
     }
 
     public Server getServer() {

--- a/tools/gcc-bridge/compiler/build.gradle
+++ b/tools/gcc-bridge/compiler/build.gradle
@@ -4,8 +4,8 @@ dependencies {
     compile project(':tools:gcc-bridge:runtime')
     compile libraries.guava
     compile libraries.asm
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.8.11.1'
-    compile('org.soot-oss:soot:4.2.1') {
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
+    compile('org.soot-oss:soot:4.3.0') {
         exclude group: 'org.smali', module: 'dexlib2'
     }
     implementation libraries.airline

--- a/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/GimpleCompiler.java
+++ b/tools/gcc-bridge/compiler/src/main/java/org/renjin/gcc/GimpleCompiler.java
@@ -619,7 +619,7 @@ public class GimpleCompiler  {
         paths.add(url.toString());
       }
     }
-    return paths.stream().collect(Collectors.joining(":"));
+    return String.join(":", paths);
   }
 
 

--- a/tools/gcc-bridge/maven-plugin/build.gradle
+++ b/tools/gcc-bridge/maven-plugin/build.gradle
@@ -1,10 +1,10 @@
 
 
 dependencies {
-    compile 'org.apache.maven:maven-plugin-api:2.0'
+    compile 'org.apache.maven:maven-plugin-api:3.3.9'
     compile 'org.apache.maven:maven-project:2.2.1'
-    compileOnly 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.4'
-    compile 'org.codehaus.plexus:plexus-compiler-api:${plexusCompilerVersion}'
+    compileOnly 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.6.4'
+    compile 'org.codehaus.plexus:plexus-compiler-api:2.9.0'
     compile 'org.renjin:gcc-bridge-compiler:${project.version}'
     testCompile libraries.junit
 }

--- a/tools/gcc-bridge/maven-plugin/pom.xml
+++ b/tools/gcc-bridge/maven-plugin/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/tools/gnur-compiler/build.gradle
+++ b/tools/gnur-compiler/build.gradle
@@ -21,7 +21,7 @@
 
 dependencies {
     compile libraries.guava
-    compile 'com.google.code.findbugs:jsr305:3.0.0'
+    compile 'com.google.code.findbugs:jsr305:3.0.2'
     compile project(':tools:gnur-runtime')
     compile project(':tools:gcc-bridge:gcc-bridge-compiler')
     compile libraries.airline

--- a/tools/maven-plugin/build.gradle
+++ b/tools/maven-plugin/build.gradle
@@ -8,12 +8,12 @@ dependencies {
     compile project(':tools:gnur-compiler')
     compile project(':tools:packager')
 
-    compile 'org.apache.maven:maven-plugin-api:2.0'
-    compile 'org.apache.maven:maven-model:2.0'
+    compile 'org.apache.maven:maven-plugin-api:3.3.9'
+    compile 'org.apache.maven:maven-model:3.3.9'
     compile 'org.apache.maven:maven-project:2.2.1'
-    compile 'org.apache.maven.surefire:surefire-api:2.13'
-    compile 'org.apache.maven:maven-core:3.0.4'
-    compileOnly 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.4'
+    compile 'org.apache.maven.surefire:surefire-api:2.22.2'
+    compile 'org.apache.maven:maven-core:3.3.9'
+    compile 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.6.4'
 
     testCompile libraries.junit
 }

--- a/tools/maven-plugin/src/main/resources/META-INF/maven/plugin.xml
+++ b/tools/maven-plugin/src/main/resources/META-INF/maven/plugin.xml
@@ -426,13 +426,13 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
             <type>jar</type>
-            <version>1.18</version>
+            <version>1.21</version>
         </dependency>
         <dependency>
             <groupId>org.tukaani</groupId>
             <artifactId>xz</artifactId>
             <type>jar</type>
-            <version>1.8</version>
+            <version>1.9</version>
         </dependency>
         <dependency>
             <groupId>org.renjin</groupId>
@@ -486,19 +486,19 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <type>jar</type>
-            <version>2.8.11.1</version>
+            <version>2.13.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <type>jar</type>
-            <version>2.8.0</version>
+            <version>2.13.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <type>jar</type>
-            <version>2.8.10</version>
+            <version>2.13.1</version>
         </dependency>
         <dependency>
             <groupId>io.airlift</groupId>
@@ -570,13 +570,13 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <type>jar</type>
-            <version>1.7.5</version>
+            <version>1.7.35</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <type>jar</type>
-            <version>1.7.5</version>
+            <version>1.7.35</version>
         </dependency>
         <dependency>
             <groupId>org.renjin</groupId>

--- a/tools/maven-plugin/src/test/java/org/renjin/maven/test/ForkedTestControllerTest.java
+++ b/tools/maven-plugin/src/test/java/org/renjin/maven/test/ForkedTestControllerTest.java
@@ -149,7 +149,9 @@ public class ForkedTestControllerTest extends TestCase {
   
   private File testFile(String name) {
     URL resource = Resources.getResource(name);
-    return new File(resource.getFile());
+    File file = new File(resource.getFile());
+    assertTrue(name + " does not exist", file.exists());
+    return file;
   }
   
   public void assertTestCaseSucceeded(File file, boolean expectSuccess) {

--- a/tools/packager/src/main/java/org/renjin/packaging/test/TestReporter.java
+++ b/tools/packager/src/main/java/org/renjin/packaging/test/TestReporter.java
@@ -82,13 +82,13 @@ public class TestReporter {
 
 
   private void printResultsBanner(PrintStream out) {
-    out.println(format("Tests run: %d, Failures: %d, Errors: %d, Skipped: %d, Time elapsed: %.3f %s",
+    out.printf("Tests run: %d, Failures: %d, Errors: %d, Skipped: %d, Time elapsed: %.3f %s%n",
         currentSuite.getResults().size(),
         currentSuite.countOutcomes(TestOutcome.FAILURE),
         currentSuite.countOutcomes(TestOutcome.ERROR),
         currentSuite.countOutcomes(TestOutcome.SKIPPED),
         currentSuite.getTime(),
-        currentSuite.hasFailures() ? " << FAILURE!" : ""));
+        currentSuite.hasFailures() ? " << FAILURE!" : "");
   }
 
   public void testCaseStarting(String name) {
@@ -105,14 +105,19 @@ public class TestReporter {
 
 
   public void timeout(long timeoutLengthMs) {
+    if (currentCase == null) {
+      System.err.println("currentCase is null, testCaseStarting was not called before timeout");
+      testCaseStarting("unknown");
+    }
+
     currentCase.setOutcome(TestOutcome.ERROR);
     currentCase.setErrorMessage("Timed out after " + timeoutLengthMs + " ms");
     if (currentCase.isRootScript()) {
-      System.err.println(format("Evaluation of %s timed out", currentSuite.getScriptFile().getName()));
+      System.err.printf("Evaluation of %s timed out%n", currentSuite.getScriptFile().getName());
     } else {
-      System.err.println(format("%s() in %s timed out",
+      System.err.printf("%s() in %s timed out%n",
           currentCase.getName(),
-          currentSuite.getScriptFile().getName()));
+          currentSuite.getScriptFile().getName());
     }
     functionComplete();
   }
@@ -130,12 +135,12 @@ public class TestReporter {
     currentCase.setErrorMessage(message);
     currentCase.setOutcome(TestOutcome.ERROR);
     if(currentCase.isRootScript()) {
-      System.err.println(format("Evaluation of %s failed",
-          currentSuite.getScriptFile().getName()));
+      System.err.printf("Evaluation of %s failed%n",
+          currentSuite.getScriptFile().getName());
     } else {
-      System.err.println(format("%s() in %s failed",
+      System.err.printf("%s() in %s failed%n",
           currentCase.getName(),
-          currentSuite.getScriptFile().getName()));
+          currentSuite.getScriptFile().getName());
     }
     functionComplete();
   }


### PR DESCRIPTION
Some of our dependencies have know security issues in the version we are using. I upgraded everything I could that does not require any changes to code. The remaining 3 (vfs, jline and commons-math require quite a lot of changes so saving those for a rainy day;) 
- aetherVersion = "1.0.2.v20150114" to "1.1.0"
- mavenVersion = "3.1.0" to "3.3.9"
- org.apache.maven:maven-plugin-api:2.0 -> 3.3.9
- org.apache.maven:maven-model:2.0 -> 3.3.9
- org.codehaus.plexus:plexus-compiler-api:${plexusCompilerVersion} -> 2.9.0
- org.apache.maven.plugin-tools:maven-plugin-annotations:3.4' - > 3.6.4
- org.apache.maven.surefire:surefire-api:2.13 -> 2.22.2
- org.json:json:20180130 - > 20211205
- add "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5" to get org.codehaus.plexus.logging.AbstractLogEnabled
. Junit:4.11 -> 4.13.2
- org.slf4j:slf4j-api:1.6.1, 1.7.5 - 1.7.35
- org.slf4j:slf4j-jdk14:1.6.1 -> 1.7.35
- org.slf4j:slf4j-simple:1.7.5 -> 1.7.35
- org.easymock:easymock:3.1 -> 4.3
- javax.servlet:javax.servlet-api:3.0.1 -> 4.0.1
- javax.servlet:javax.servlet-api:3.0.1 -> 4.0.1
- org.jfree:jfreesvg:3.3 -> 3.4.2
- org.soot-oss:soot:4.2.1 -> 4.3.0
- org.apache.commons:commons-compress:1.18 -> 1.21
- org.tukaani:xz:1.8 -> 1.9
- com.fasterxml.jackson.core:jackson-databind:2.8.11.1 -> 2.13.1
- com.fasterxml.jackson.core:jackson-annotations:2.8.0 -> 2.13.1
- com.fasterxml.jackson.core:jackson-core:2.8.10 -> 2.13.1
- com.google.code.findbugs:jsr305:3.0.0 -> 3.0.2

Mirror .m2 dir to /home/vagrant/.m2 to enable ./gradlew publishToMavenLocal

Minor code cleanup

I've noticed that sometimes there is a timing issue with the forked test (it times out before the test name has been set resulting in an NPE) it is intermittent and difficult to repeat reliably so i just added a simple NPE safeguard.

I have run through the entire build a couple of times with no issues and also run some example code using the build to verify things without seeing any problems.