### PR TITLE
fix getwd() on windows

### DIFF
--- a/core/src/main/java/org/renjin/primitives/files/Files.java
+++ b/core/src/main/java/org/renjin/primitives/files/Files.java
@@ -843,7 +843,10 @@ public class Files {
    */
   private static String friendlyFileName(FileObject file) {
     String uri = file.getName().getURI();
-    if(uri.startsWith("file://")) {
+    if(uri.startsWith("file:///")) {
+      if (isWindows()) {
+        return uri.substring("file:///".length());
+      }
       return uri.substring("file://".length());
     }
     return uri;


### PR DESCRIPTION
remove leading front slash on windows in Files.friendlyFileName()
Resolves #549
